### PR TITLE
Allow pointers to be implicitly converted

### DIFF
--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -145,6 +145,16 @@ impl Type {
         }
     }
     #[inline]
+    pub fn is_char_pointer(&self) -> bool {
+        match self {
+            Type::Pointer(t, _) => match **t {
+                Type::Char(_) => true,
+                _ => false,
+            },
+            _ => false,
+        }
+    }
+    #[inline]
     /// used for pointer addition and subtraction, see section 6.5.6 of the C11 standard
     pub fn is_pointer_to_complete_object(&self) -> bool {
         match self {

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1176,14 +1176,8 @@ impl Expr {
         } else if self.ctype.is_arithmetic() && ctype.is_arithmetic()
             || self.is_null() && ctype.is_pointer()
             || self.ctype.is_pointer() && ctype.is_bool()
-            || self.ctype.is_pointer()
-                && match ctype {
-                    Type::Pointer(t, _) => match **t {
-                        Type::Void => true,
-                        _ => false,
-                    },
-                    _ => false,
-                }
+            || self.ctype.is_pointer() && ctype.is_void_pointer()
+            || self.ctype.is_pointer() && ctype.is_char_pointer()
         {
             Ok(Expr {
                 location: self.location.clone(),
@@ -1192,8 +1186,10 @@ impl Expr {
                 lval: false,
                 ctype: ctype.clone(),
             })
-        } else if self.expr == ExprType::Literal(Token::Int(0)) && ctype.is_pointer()
-            || self.ctype.is_void_pointer() && ctype.is_pointer()
+        } else if ctype.is_pointer()
+            && (self.expr == ExprType::Literal(Token::Int(0))
+                || self.ctype.is_void_pointer()
+                || self.ctype.is_char_pointer())
         {
             self.ctype = ctype.clone();
             Ok(self)

--- a/tests/expr.rs
+++ b/tests/expr.rs
@@ -197,6 +197,17 @@ fn implicit_casts() {
     utils::assert_code("int main() { return 12.0 == 12; }", 1);
     utils::assert_code("int main() { return 12.0 <= 12; }", 1);
     utils::assert_code("int main() { return 1 + 2 > 1; }", 1);
+    utils::assert_code(
+        "int main() {
+        int i = 1, *p = &i;
+        char *c = p;
+        void *d = p;
+        p = d;
+        c = d;
+        return *c;
+        }",
+        1,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Allows pointers to be implicitly converted to and from void* and char*

Closes https://github.com/jyn514/rcc/issues/64