### PR TITLE
Allow any expression in sizeof()

### DIFF
--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -533,7 +533,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                             (ty.location, ty.data.0)
                         }
                         _ => {
-                            let expr = self.unary_expr()?;
+                            let expr = self.expr()?;
                             (expr.location, expr.ctype)
                         }
                     };

--- a/tests/expr.rs
+++ b/tests/expr.rs
@@ -182,7 +182,7 @@ fn comma() {
 #[test]
 fn sizeof() {
     utils::assert_code(
-        "int main() { return sizeof(1) + sizeof 1 + sizeof(long); }",
+        "int main() { return sizeof(1 + 1) + sizeof 1 + sizeof(long); }",
         3 * rcc::data::Type::Long(true).sizeof().unwrap() as i32,
     );
 }


### PR DESCRIPTION
I was special casing sizeof '(' <not a declaration specifier> ')' and I special-cased it wrong.

Thanks to @xTachyon for the bug report.