### PR TITLE
Fix alignment calculation for structs

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -50,7 +50,7 @@ pub fn struct_size(symbols: &[Symbol]) -> Result<SIZE_T, &'static str> {
 
 pub fn struct_align(members: &[Symbol]) -> Result<SIZE_T, &'static str> {
     members.iter().try_fold(0, |max, member| {
-        Ok(std::cmp::max(member.ctype.sizeof()?, max))
+        Ok(std::cmp::max(member.ctype.alignof()?, max))
     })
 }
 

--- a/tests/decls.rs
+++ b/tests/decls.rs
@@ -209,6 +209,15 @@ fn enum_self_assign() {
 }
 
 #[test]
+fn alignment() {
+    utils::assert_code(
+        "struct s { int a[24]; } my_s;
+         int main() { return *my_s.a; }",
+        0,
+    );
+}
+
+#[test]
 fn function() {
     utils::assert_code(
         "


### PR DESCRIPTION
Fixes crash mentioned in https://github.com/jyn514/rcc/issues/76