### PR TITLE
Fix structs once and for all (until the compiler is parallel)

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -14,7 +14,7 @@ pub mod prelude {
             CompileError, CompileResult, Recoverable, RecoverableResult, SemanticError, SyntaxError,
         },
         lex::{Locatable, Location, Token},
-        types::{StructType, Type},
+        types::{StructRef, StructType, Type},
         Declaration, Expr, ExprType, Stmt, StmtType, Symbol,
     };
     pub use crate::intern::InternedStr;
@@ -140,7 +140,7 @@ pub enum ExprType {
     Noop(Box<Expr>),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum StorageClass {
     Static = Keyword::Static as isize,
     Extern = Keyword::Extern as isize,
@@ -159,7 +159,7 @@ pub struct Symbol {
     pub init: bool,
 }
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Qualifiers {
     pub volatile: bool,
     pub c_const: bool,
@@ -186,10 +186,6 @@ impl Qualifiers {
         c_const: true,
         volatile: true,
     };
-}
-
-lazy_static! {
-    pub static ref INT_POINTER: Type = { Type::Pointer(Box::new(Type::Int(true))) };
 }
 
 pub enum LengthError {

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -21,7 +21,7 @@ enum FuncCall {
     Indirect(Value),
 }
 
-impl<'a> Compiler<'a> {
+impl Compiler {
     // clippy doesn't like big match statements, but this is kind of essential complexity,
     // it can't be any smaller without supporting fewer features
     #[allow(clippy::cognitive_complexity)]

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -23,7 +23,6 @@ use cranelift_module::{self, DataId, FuncId, Linkage, Module as CraneliftModule}
 
 use crate::arch::TARGET;
 use crate::data::{prelude::*, types::FunctionType, Initializer, Scope, StorageClass};
-use crate::parse::TagScope;
 use crate::utils;
 
 type Module = CraneliftModule<FaerieBackend>;
@@ -34,10 +33,9 @@ enum Id {
     Local(StackSlot),
 }
 
-struct Compiler<'a> {
+struct Compiler {
     module: Module,
     scope: Scope<InternedStr, Id>,
-    tag_scope: &'a TagScope,
     debug: bool,
     // if false, we last saw a switch
     last_saw_loop: bool,
@@ -51,16 +49,12 @@ struct Compiler<'a> {
 }
 
 /// Compile a program from a high level IR to a Cranelift Module
-pub(crate) fn compile(
-    program: Vec<Locatable<Declaration>>,
-    debug: bool,
-    tag_scope: &TagScope,
-) -> CompileResult<Module> {
+pub(crate) fn compile(program: Vec<Locatable<Declaration>>, debug: bool) -> CompileResult<Module> {
     let name = program.first().map_or_else(
         || "<empty>".to_string(),
         |decl| decl.location.file.resolve_and_clone(),
     );
-    let mut compiler = Compiler::new(name, debug, tag_scope);
+    let mut compiler = Compiler::new(name, debug);
     for decl in program {
         match (decl.data.symbol.ctype.clone(), decl.data.init) {
             (Type::Function(func_type), None) => {
@@ -89,8 +83,8 @@ pub(crate) fn compile(
     Ok(compiler.module)
 }
 
-impl<'a> Compiler<'a> {
-    fn new(name: String, debug: bool, tag_scope: &TagScope) -> Compiler {
+impl Compiler {
+    fn new(name: String, debug: bool) -> Compiler {
         let mut flags_builder = settings::builder();
         // allow creating shared libraries
         flags_builder
@@ -120,7 +114,6 @@ impl<'a> Compiler<'a> {
         Compiler {
             module: Module::new(builder),
             scope: Scope::new(),
-            tag_scope,
             loops: Vec::new(),
             switches: Vec::new(),
             labels: HashMap::new(),

--- a/src/ir/stmt.rs
+++ b/src/ir/stmt.rs
@@ -5,7 +5,7 @@ use cranelift::prelude::{Ebb, FunctionBuilder, InstBuilder};
 use super::Compiler;
 use crate::data::prelude::*;
 
-impl<'a> Compiler<'a> {
+impl Compiler {
     pub(crate) fn compile_all(
         &mut self,
         stmts: Vec<Stmt>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn compile(
         return Err(Error::Source(all_errs));
     }
 
-    ir::compile(hir, debug_ir, parser.tag_scope())
+    ir::compile(hir, debug_ir)
         .map_err(Error::from)
         .map(Module::<FaerieBackend>::finish)
 }

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -16,7 +16,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
     /* grammar functions
      * this parser is a top-down, recursive descent parser
      * and uses a modified version of the ANSI C Yacc grammar published at
-     * https://www.lysator.liu.se/c, self.all_structs)/ANSI-C-grammar-y.html.
+     * https://www.lysator.liu.se/c/ANSI-C-grammar-y.html.
      * Differences from the original grammar, if present, are noted
      * before each function.
      */
@@ -707,32 +707,6 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                 TagEntry::Union
             }(struct_ref);
             self.tag_scope.insert(id, entry);
-            /*
-            let (size, align, offset) = match Self::struct_type(members, c_struct) {
-                Ok(tup) => tup,
-                Err(err) => {
-                    self.semantic_err(err, *location);
-                    return Ok(Type::Error);
-                }
-            };
-            for tag in self.tag_scope.get_all_immediate().values_mut() {
-                match tag {
-                    TagEntry::Union(members) | TagEntry::Struct(members) => {
-                        for member in members.iter_mut() {
-                            Self::update_forward_declarations(
-                                &mut member.ctype,
-                                (size, align, &offset),
-                                id,
-                            )
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            for variable in self.scope.get_all_immediate().values_mut() {
-                Self::update_forward_declarations(&mut variable.ctype, (size, align, &offset), id);
-            }
-            */
             Ok(constructor(StructType::Named(id, struct_ref)))
         } else {
             Ok(constructor(StructType::Anonymous(Rc::new(members))))
@@ -1287,54 +1261,6 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         self.leave_scope(self.last_location);
         body
     }
-    /* shouldn't be necessary since everything stores a reference to TYPES
-    fn update_forward_declarations(
-        ctype: &mut Type,
-        new_type: (u64, u64, &HashMap<InternedStr, u64>),
-        ident: InternedStr,
-    ) {
-        use Type::*;
-        match ctype {
-            // nothing to do, best to hope that the previous declaration was valid
-            Error => {}
-            Array(inner, _) | Pointer(inner) => {
-                Self::update_forward_declarations(inner, new_type, ident)
-            }
-            Function(ftype) => {
-                Self::update_forward_declarations(&mut ftype.return_type, new_type, ident);
-                for param in ftype.params.iter_mut() {
-                    Self::update_forward_declarations(&mut param.ctype, new_type, ident);
-                }
-            }
-            Union(StructType::Named(name, size @ 0, align @ 0, offset))
-            | Struct(StructType::Named(name, size @ 0, align @ 0, offset))
-                if *name == ident =>
-            {
-                *size = new_type.0;
-                *align = new_type.1;
-                *offset = new_type.2.clone();
-            }
-            Union(StructType::Anonymous(members)) | Struct(StructType::Anonymous(members)) => {
-                for member in members {
-                    Self::update_forward_declarations(&mut member.ctype, new_type, ident)
-                }
-            }
-            Void
-            | Bool
-            | Char(_)
-            | Short(_)
-            | Int(_)
-            | Long(_)
-            | Enum(_, _)
-            | Float
-            | Double
-            | Union(_)
-            | Struct(_)
-            | VaList => {}
-            Bitfield(_) => unimplemented!("updating bitfield after typedef"),
-        }
-    }
-    */
     #[inline]
     /* the reason this is such a mess (instead of just putting everything into
      * the hashmap, which would be much simpler logic) is so we have a Location

--- a/tests/runner-tests/decls/forward_declaration/5.c
+++ b/tests/runner-tests/decls/forward_declaration/5.c
@@ -1,4 +1,4 @@
-// errors: 2
+// fail
 struct s {
     int f();
 } my_s;

--- a/tests/runner-tests/decls/forward_struct_declaration.c
+++ b/tests/runner-tests/decls/forward_struct_declaration.c
@@ -1,9 +1,8 @@
-// ignore: https://github.com/jyn514/rcc/issues/44
 // succeeds
 struct s my_s;
-    struct s {
-        int i;
-    };
-    int main() {
-        return my_s.i;
-    }
+struct s {
+    int i;
+};
+int main() {
+    return my_s.i;
+}


### PR DESCRIPTION
Use a thread_local TYPES global to allow looking up struct definitions from anywhere.
Use a `StructRef` type to look up members.

Allows a unified interface for `members()`.
Allows using struct definitions in the backend even after types have gone out of scope.

Removes unneeded caching for `struct_size`, `struct_align`, and `struct_offset` functions.
Removes unneeded `struct_type` function.
Removes several repetitive matches in favor of `members()`.
Removes unneeded lifetime and `tag_scope` parameter for `Compiler` struct.

See inline documentation for more details.

Closes #126 , #44. Helps a great deal with #53.