### PR TITLE
Static keyword in for array sizes in function parameters

### DIFF
--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1714,18 +1714,18 @@ mod tests {
     fn test_pointers_and_arrays() {
         // cdecl: declare foo as array 10 of pointer to pointer to char
         assert!(match_type(
-            parse("char **foo[];"),
+            parse("char **foo[10];"),
             Array(
                 Box::new(Pointer(Box::new(Pointer(Box::new(Char(true)))))),
-                ArrayType::Unbounded,
+                ArrayType::Fixed(10),
             )
         ));
         // cdecl: declare foo as pointer to pointer to array 10 of int
         assert!(match_type(
-            parse("int (**foo)[];"),
+            parse("int (**foo)[10];"),
             Pointer(Box::new(Pointer(Box::new(Array(
                 Box::new(Int(true)),
-                ArrayType::Unbounded
+                ArrayType::Fixed(10)
             )))),)
         ));
     }

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1814,6 +1814,25 @@ mod tests {
         ));
     }
     #[test]
+    fn test_functions_array_parameter_static() {
+        assert!(match_type(
+            parse("void f(int a[static 5]);"), 
+            Function(FunctionType {
+                return_type: Box::new(Void),
+                params: vec![Symbol {
+                    id: InternedStr::get_or_intern("a"),
+                    ctype: Pointer(Box::new(Int(true))),
+                    qualifiers: Default::default(),
+                    storage_class: Default::default(),
+                    init: true,
+                }],
+                varargs: false
+            })
+        ));
+
+        assert!(parse("int b[static 10];").unwrap().is_err());
+    }
+    #[test]
     fn test_complex() {
         // cdecl: declare bar as const pointer to array 10 of pointer to function (int) returning const pointer to char
         assert!(match_type(

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -937,12 +937,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                                 // TODO: Add information for the compiler to know
                                 // to warn if `NULL` is passed into the function
                             } else {
-                                return Err(SyntaxError(Locatable {
-                                    data:
-                                        "`static` keyword for array sizes is only allowed in function declarations"
-                                            .to_string(),
-                                    location: keyword.location,
-                                }));
+                                self.semantic_err("`static` keyword for array sizes is only allowed in function declarations", keyword.location);
                             }
                         }
 

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1816,7 +1816,7 @@ mod tests {
     #[test]
     fn test_functions_array_parameter_static() {
         assert!(match_type(
-            parse("void f(int a[static 5]);"), 
+            parse("void f(int a[static 5]);"),
             Function(FunctionType {
                 return_type: Box::new(Void),
                 params: vec![Symbol {

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -939,7 +939,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                             } else {
                                 return Err(SyntaxError(Locatable {
                                     data:
-                                        "`static` keyword is only allowed in function declarations"
+                                        "`static` keyword for array sizes is only allowed in function declarations"
                                             .to_string(),
                                     location: keyword.location,
                                 }));


### PR DESCRIPTION
Allows the use of the `static` keyword for array sizes in function parameters.

Fixes #62