### PR TITLE
Refactor .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,18 +21,10 @@ jobs:
                 - gcc
                 - binutils-dev
                 - libiberty-dev
+                - libssl-dev
+          before_cache: cargo install cargo-tarpaulin -f
           after_success: |
-              wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
-              tar xzf master.tar.gz &&
-              cd kcov-master &&
-              mkdir build &&
-              cd build &&
-              cmake .. &&
-              make &&
-              make install DESTDIR=../../kcov-build &&
-              cd ../.. &&
-              rm -rf kcov-master &&
-              for file in target/debug/rcc-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+              cargo tarpaulin --out Xml &&
               bash <(curl -s https://codecov.io/bash) &&
               echo "Uploaded code coverage"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: rust
 
-cache:
-    cargo: ""
-
 jobs:
     include:
         - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,50 @@
 language: rust
-rust:
-    - stable
-    - beta
-    - nightly
 
 cache:
     cargo: ""
 
-install:
-    - rustup component add rustfmt
-    - rustup component add clippy
+jobs:
+    include:
+        - rust: stable
+          install:
+            - rustup component add rustfmt
+            - rustup component add clippy
 
-script:
-    - tests/pre-commit.sh
-    - echo $TRAVIS_RUST_VERSION; if [ $TRAVIS_RUST_VERSION = "nightly" ]; then tests/fuzz.sh || true; fi
+          script:
+          - tests/pre-commit.sh
+          # upload coverage statistics to codecov.io
+          env: RUSTFLAGS="-C link-dead-code"
+          addons:
+            apt:
+              packages:
+                - libcurl4-openssl-dev
+                - libelf-dev
+                - libdw-dev
+                - cmake
+                - gcc
+                - binutils-dev
+                - libiberty-dev
+          after_success: |
+              wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
+              tar xzf master.tar.gz &&
+              cd kcov-master &&
+              mkdir build &&
+              cd build &&
+              cmake .. &&
+              make &&
+              make install DESTDIR=../../kcov-build &&
+              cd ../.. &&
+              rm -rf kcov-master &&
+              for file in target/debug/rcc-*; do [ -x "${file}" ] || continue; mkdir -p "target/cov/$(basename $file)"; ./kcov-build/usr/local/bin/kcov --exclude-pattern=/.cargo,/usr/lib --verify "target/cov/$(basename $file)" "$file"; done &&
+              bash <(curl -s https://codecov.io/bash) &&
+              echo "Uploaded code coverage"
 
-matrix:
-    allow_failures:
-        - rust: nightly
         - rust: beta
-    fast_finish: true
+          # sometimes rustfmt changes its mind about formatting between releases
+          script: cargo test
+
+        - rust: nightly
+          # afl needs nightly
+          script:
+            - cargo test
+            - tests/fuzz.sh


### PR DESCRIPTION
- add codecov using `cargo-tarpaulin` on stable
- don't run clippy and rustfmt on beta and nightly
- don't cache build artifacts (since downloading them takes longer than just recompiling)

