### PR TITLE
Make CompileError a different type of enum

### DIFF
--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -137,9 +137,15 @@ impl CompileError {
     pub fn location(&self) -> Location {
         self.location
     }
-    pub fn is_lex_err(&self) -> bool { self.data.is_lex_err() }
-    pub fn is_syntax_err(&self) -> bool { self.data.is_syntax_err() }
-    pub fn is_semantic_err(&self) -> bool { self.data.is_semantic_err() }
+    pub fn is_lex_err(&self) -> bool {
+        self.data.is_lex_err()
+    }
+    pub fn is_syntax_err(&self) -> bool {
+        self.data.is_syntax_err()
+    }
+    pub fn is_semantic_err(&self) -> bool {
+        self.data.is_semantic_err()
+    }
 }
 
 impl Error {
@@ -199,12 +205,6 @@ impl<S: Into<String>> From<S> for SemanticError {
 impl<S: Into<String>> From<S> for SyntaxError {
     fn from(err: S) -> Self {
         SyntaxError::Generic(err.into())
-    }
-}
-
-impl From<String> for LexError {
-    fn from(err: String) -> Self {
-        LexError::Generic(err)
     }
 }
 
@@ -316,7 +316,10 @@ mod tests {
 
     #[test]
     fn test_compile_error_from_syntax_error() {
-        let _ = CompileError::new(SyntaxError::from("oranges".to_string()).into(), Location::default());
+        let _ = CompileError::new(
+            SyntaxError::from("oranges".to_string()).into(),
+            Location::default(),
+        );
     }
 
     #[test]

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -187,7 +187,7 @@ impl<T: PartialEq> PartialEq for Locatable<T> {
 
 impl<T: Eq> Eq for Locatable<T> {}
 impl<T> Locatable<T> {
-    pub fn new(data: T, location: Location) -> Self {
+    pub const fn new(data: T, location: Location) -> Self {
         Self { data, location }
     }
 }

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::str::Chars;
 
-use super::data::{lex::*, prelude::*, error::LexError};
+use super::data::{error::LexError, lex::*, prelude::*};
 use super::intern::InternedStr;
 
 /// A Lexer takes the source code and turns it into tokens with location information.
@@ -847,15 +847,15 @@ impl<'a> Iterator for Lexer<'a> {
             println!("lexeme: {:?}", c);
         }
         // oof
-        c.map(|result| {
-            result.map_err(|err| err.map(|err| LexError::Generic(err).into()))
-        })
+        c.map(|result| result.map_err(|err| err.map(|err| LexError::Generic(err).into())))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{LexError, CompileError, CompileResult, Error, Lexer, Literal, Locatable, Location, Token};
+    use super::{
+        CompileError, CompileResult, Error, LexError, Lexer, Literal, Locatable, Location, Token,
+    };
     use crate::intern::InternedStr;
 
     type LexType = CompileResult<Locatable<Token>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ fn err_exit(err: Error) -> ! {
     match err {
         Source(errs) => {
             for err in errs {
-                error(&err, err.location());
+                error(&err.data, err.location());
             }
             let (num_warnings, num_errors) = (get_warnings(), get_errors());
             print_issues(num_warnings, num_errors);

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -118,7 +118,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                 )?))
             }
             (Type::Function(_), Some(t)) if *t == Token::EQUAL => {
-                return Err(SyntaxError(Locatable {
+                return Err(SyntaxError::from(Locatable {
                     data: format!(
                         "expected '{{', got '=' while parsing function body for {}",
                         symbol.id,
@@ -357,10 +357,11 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         let mut seen_compound = false;
         let mut seen_typedef = false;
         if self.peek_token().is_none() {
-            return Err(SyntaxError(Locatable {
-                data: "expected declaration specifier, got <end-of-file>".into(),
+            return Err(SyntaxError::try_from(Locatable {
+                data: Error::EndOfFile("declaration specifier"),
                 location: self.last_location,
-            }));
+            })
+            .unwrap());
         }
         // unsigned const int
         while let Some(locatable) = self.next_token() {

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use std::iter::{FromIterator, Iterator};
 use std::mem;
 
-use super::{FunctionData, Lexeme, Parser, TagEntry, SyntaxResult};
+use super::{FunctionData, Lexeme, Parser, SyntaxResult, TagEntry};
 use crate::arch::SIZE_T;
 use crate::data::{
     lex::Keyword,
@@ -475,11 +475,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         | ENUM identifier
         ;
     */
-    fn compound_specifier(
-        &mut self,
-        kind: Keyword,
-        location: Location,
-    ) -> SyntaxResult<Type> {
+    fn compound_specifier(&mut self, kind: Keyword, location: Location) -> SyntaxResult<Type> {
         use std::rc::Rc;
         let ident = match self.match_next(&Token::Id(Default::default())) {
             Some(Locatable {
@@ -1532,12 +1528,15 @@ impl Declarator {
     /// Explanation of the return type:
     /// `Option<Locatable<InternedStr>>`: the name of the declarator. May not exist for abstract parameters.
     /// `RecoverableResult<...>`: see documentation for why this exists
+    // TODO: this return type is really bad
+    #[allow(clippy::type_complexity)]
     fn parse_type(
         self,
         mut current: Type,
         is_typedef: bool,
         location: &Location, // only used for abstract parameters
-    ) -> RecoverableResult<(Option<Locatable<InternedStr>>, Type), Vec<Locatable<SemanticError>>> {
+    ) -> RecoverableResult<(Option<Locatable<InternedStr>>, Type), Vec<Locatable<SemanticError>>>
+    {
         use DeclaratorType::*;
         let (mut declarator, mut identifier) = (Some(self), None);
         let mut pending_errs = vec![];

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -886,7 +886,10 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                 other => {
                     let err = Err(Locatable {
                         location,
-                        data: SyntaxError::from(format!("expected '(' or literal in expression, got '{}'", other)),
+                        data: SyntaxError::from(format!(
+                            "expected '(' or literal in expression, got '{}'",
+                            other
+                        )),
                     });
                     self.unput(Some(Locatable {
                         location,
@@ -1047,7 +1050,11 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         mut expr_func: E,
     ) -> SyntaxResult
     where
-        E: FnMut(Box<Expr>, Box<Expr>, Locatable<Token>) -> RecoverableResult<Expr, Locatable<SemanticError>>,
+        E: FnMut(
+            Box<Expr>,
+            Box<Expr>,
+            Locatable<Token>,
+        ) -> RecoverableResult<Expr, Locatable<SemanticError>>,
         G: Fn(&mut Self) -> SyntaxResult,
     {
         let mut expr = next_grammar_func(self)?;
@@ -1172,7 +1179,10 @@ impl Expr {
     // Perform a binary conversion, including all relevant casts.
     //
     // See `Type::binary_promote` for conversion rules.
-    fn binary_promote(left: Expr, right: Expr) -> RecoverableResult<(Expr, Expr), Locatable<SemanticError>> {
+    fn binary_promote(
+        left: Expr,
+        right: Expr,
+    ) -> RecoverableResult<(Expr, Expr), Locatable<SemanticError>> {
         let (left, right) = (left.rval(), right.rval());
         let ctype = Type::binary_promote(left.ctype.clone(), right.ctype.clone());
         match (left.cast(&ctype), right.cast(&ctype)) {
@@ -1262,7 +1272,8 @@ impl Expr {
                         } else {
                             String::new()
                         }
-                    ).into(),
+                    )
+                    .into(),
                 },
                 self,
             ))
@@ -1292,7 +1303,8 @@ impl Expr {
                     "cannot perform pointer arithmetic when size of pointed type '{}' is unknown",
                     pointee
                 ),
-                    }.into(),
+                    }
+                    .into(),
                     base,
                 ))
             }
@@ -1331,7 +1343,8 @@ impl Expr {
                 Locatable {
                     location: expr.location,
                     data: "expression is not assignable".to_string(),
-                }.into(),
+                }
+                .into(),
                 expr,
             ));
         } else if !(expr.ctype.is_arithmetic() || expr.ctype.is_pointer()) {
@@ -1342,7 +1355,8 @@ impl Expr {
                         "cannot increment or decrement value of type '{}'",
                         expr.ctype
                     ),
-                }.into(),
+                }
+                .into(),
                 expr,
             ));
         }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -14,7 +14,6 @@ pub(crate) type TagScope = Scope<InternedStr, TagEntry>;
 
 type SyntaxResult<T = Expr> = Result<T, Locatable<SyntaxError>>;
 
-
 #[derive(Clone, Debug)]
 pub(crate) enum TagEntry {
     Struct(StructRef),

--- a/src/parse/stmt.rs
+++ b/src/parse/stmt.rs
@@ -1,6 +1,7 @@
 use super::{Lexeme, Parser};
 use crate::data::prelude::*;
 use crate::data::{lex::Keyword, StorageClass};
+use std::convert::TryFrom;
 use std::iter::Iterator;
 
 type StmtResult = Result<Stmt, SyntaxError>;
@@ -388,10 +389,13 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                 })),
                 None => None,
             },
-            None => syntax_err!(
-                "expected expression or ';', got <end-of-file>".to_string(),
-                self.last_location,
-            ),
+            None => {
+                return Err(SyntaxError::try_from(CompileError::new(
+                    Error::EndOfFile("expression or ';'"),
+                    self.last_location,
+                ))
+                .unwrap())
+            }
         };
         let controlling_expr = self
             .expr_opt(Token::Semicolon)?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,16 +108,6 @@ macro_rules! semantic_err {
     };
 }
 
-macro_rules! syntax_err {
-    ($message: expr, $location: expr$(,)?) => {
-        return Err(Locatable {
-            data: $message,
-            location: $location,
-        }
-        .into());
-    };
-}
-
 /// Check that many expressions match a pattern
 /// TODO: only works for 1, 2, or 3 arguments
 #[allow(unused_macros)]


### PR DESCRIPTION
Gets rid of `ErrorKind` in favor of just having variants for
CompileError that make more sense. Lets functions in `src/parse` be
typed as returning `SyntaxError` without having to always return a
`Locatable<String>`.

As a side effect, this removes `syntax_err!` and no longer assumes that `Locatable { String, Location }.into()` should be a semantic error.