### PR TITLE
Location::with and Location::error

### DIFF
--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -44,8 +44,7 @@ impl ErrorHandler {
     ///
     /// TODO: Remove this method
     pub(crate) fn warn<W: Into<Warning>>(&mut self, warning: W, location: Location) {
-        self.warnings
-            .push_back(Locatable::new(warning.into(), location));
+        self.warnings.push_back(location.with(warning.into()));
     }
     /// Add an iterator of errors to the error queue
     pub(crate) fn extend<E: Into<CompileError>>(&mut self, iter: impl Iterator<Item = E>) {
@@ -244,14 +243,11 @@ mod tests {
     use super::*;
 
     fn dummy_error() -> CompileError {
-        CompileError::new(
-            Error::Lex(LexError::UnterminatedComment),
-            Default::default(),
-        )
+        Location::default().with(Error::Lex(LexError::UnterminatedComment))
     }
 
     fn new_error(error: Error) -> CompileError {
-        CompileError::new(error, Location::default())
+        Location::default().with(error)
     }
 
     #[test]
@@ -279,7 +275,7 @@ mod tests {
     #[test]
     fn test_compile_error_semantic() {
         assert_eq!(
-            CompileError::semantic(Locatable::new("".to_string(), Location::default())).data,
+            CompileError::semantic(Location::default().with("".to_string())).data,
             Error::Semantic(SemanticError::Generic("".to_string())),
         );
     }
@@ -317,15 +313,12 @@ mod tests {
 
     #[test]
     fn test_compile_error_from_locatable_string() {
-        let _ = CompileError::from(Locatable::new("apples".to_string(), Location::default()));
+        let _ = CompileError::from(Location::default().with("apples".to_string()));
     }
 
     #[test]
     fn test_compile_error_from_syntax_error() {
-        let _ = CompileError::new(
-            SyntaxError::from("oranges".to_string()).into(),
-            Location::default(),
-        );
+        let _ = Location::default().error(SyntaxError::from("oranges".to_string()));
     }
 
     #[test]

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -200,6 +200,12 @@ impl<T: PartialEq> PartialEq for Locatable<T> {
 
 impl<T: Eq> Eq for Locatable<T> {}
 
+impl<T> Locatable<T> {
+    pub fn new(data: T, location: Location) -> Locatable<T> {
+        location.with(data)
+    }
+}
+
 impl Token {
     pub const EQUAL: Token = Token::Assignment(AssignmentToken::Equal);
 }

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -170,7 +170,10 @@ pub enum Token {
 
 impl Location {
     pub fn with<T>(self, data: T) -> Locatable<T> {
-        Locatable { data, location: self }
+        Locatable {
+            data,
+            location: self,
+        }
     }
 
     pub fn error<E: Into<super::error::Error>>(self, error: E) -> super::CompileError {
@@ -196,11 +199,6 @@ impl<T: PartialEq> PartialEq for Locatable<T> {
 }
 
 impl<T: Eq> Eq for Locatable<T> {}
-impl<T> Locatable<T> {
-    pub const fn new(data: T, location: Location) -> Self {
-        Self { data, location }
-    }
-}
 
 impl Token {
     pub const EQUAL: Token = Token::Assignment(AssignmentToken::Equal);

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -167,6 +167,17 @@ pub enum Token {
 }
 
 /* impls */
+
+impl Location {
+    pub fn with<T>(self, data: T) -> Locatable<T> {
+        Locatable { data, location: self }
+    }
+
+    pub fn error<E: Into<super::error::Error>>(self, error: E) -> super::CompileError {
+        self.with(error.into())
+    }
+}
+
 impl PartialOrd for Location {
     /// NOTE: this only compares the start of the spans, it ignores the end
     fn partial_cmp(&self, other: &Location) -> Option<Ordering> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -209,10 +209,8 @@ impl Expr {
         match literal.data.0 {
             Literal::UnsignedInt(u) => Ok(u),
             Literal::Int(x) => x.try_into().map_err(|_| {
-                CompileError::semantic(Locatable::new(
-                    LengthError::Negative.into(),
-                    literal.location,
-                ))
+                // This is disgusting
+                CompileError::semantic(literal.location.with(LengthError::Negative.into()))
             }),
             Literal::Char(c) => Ok(u64::from(c)),
             x => unreachable!("should have been caught already: {:?}", x),

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -209,8 +209,10 @@ impl Expr {
         match literal.data.0 {
             Literal::UnsignedInt(u) => Ok(u),
             Literal::Int(x) => x.try_into().map_err(|_| {
-                // This is disgusting
-                CompileError::semantic(literal.location.with(LengthError::Negative.into()))
+                CompileError::semantic(Locatable::new(
+                    LengthError::Negative.into(),
+                    literal.location,
+                ))
             }),
             Literal::Char(c) => Ok(u64::from(c)),
             x => unreachable!("should have been caught already: {:?}", x),

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -91,9 +91,10 @@ impl Expr {
                 data: (token, folded.ctype),
                 location: folded.location,
             }),
-            _expr => {
-                Err(Locatable::new("not a constant expression".to_string(), folded.location).into())
-            }
+            _expr => Err(folded
+                .location
+                .with("not a constant expression".to_string())
+                .into()),
         }
     }
     pub fn const_fold(self) -> CompileResult<Expr> {

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -530,9 +530,7 @@ impl Compiler {
                 unreachable!("struct should not have a valid complex assignment");
             }
             use std::convert::TryInto;
-            let size = ctype
-                .sizeof()
-                .map_err(|e| Locatable::new(e.to_string(), location))?;
+            let size = ctype.sizeof().map_err(|e| location.with(e.to_string()))?;
             let align = ctype
                 .alignof()
                 .expect("if sizeof() succeeds so should alignof()")

--- a/src/ir/static_init.rs
+++ b/src/ir/static_init.rs
@@ -232,9 +232,7 @@ impl Compiler {
                         let size_host: usize = member
                             .ctype
                             .sizeof()
-                            .map_err(|err| {
-                                CompileError::semantic(Locatable::new(err.into(), *location))
-                            })?
+                            .map_err(|err| CompileError::semantic(location.with(err.to_string())))?
                             .try_into()
                             .expect("cannot initialize struct larger than u32");
                         let size: u32 = size_host

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -812,21 +812,21 @@ impl<'a> Iterator for Lexer<'a> {
                     Ok(num) => num,
                     Err(err) => {
                         let span = self.span(span_start);
-                        return Some(Err(Locatable::new(err, span)));
+                        return Some(Err(span.with(err)));
                     }
                 },
                 'a'..='z' | 'A'..='Z' | '_' => match self.parse_id(c) {
                     Ok(id) => id,
                     Err(err) => {
                         let span = self.span(span_start);
-                        return Some(Err(Locatable::new(err, span)));
+                        return Some(Err(span.with(err)));
                     }
                 },
                 '\'' => match self.parse_char() {
                     Ok(id) => id,
                     Err(err) => {
                         let span = self.span(span_start);
-                        return Some(Err(Locatable::new(err, span)));
+                        return Some(Err(span.with(err)));
                     }
                 },
                 '"' => {
@@ -835,7 +835,7 @@ impl<'a> Iterator for Lexer<'a> {
                         Ok(id) => id,
                         Err(err) => {
                             let span = self.span(span_start);
-                            return Some(Err(Locatable::new(err, span)));
+                            return Some(Err(span.with(err)));
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ pub fn compile(
         Some(token) => token,
         None => {
             if errs.is_empty() {
-                errs.push_back(CompileError::new(SemanticError::EmptyProgram.into(), eof()));
+                errs.push_back(eof().error(SemanticError::EmptyProgram));
             }
             return (Err(Error::Source(errs)), lexer.warnings());
         }
@@ -87,7 +87,7 @@ pub fn compile(
     let (hir, parse_errors) = parser.collect_results();
     errs.extend(parse_errors.into_iter());
     if hir.is_empty() && errs.is_empty() {
-        errs.push_back(CompileError::new(SemanticError::EmptyProgram.into(), eof()));
+        errs.push_back(eof().error(SemanticError::EmptyProgram));
     }
 
     let mut warnings = parser.warnings();

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1119,13 +1119,10 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
             }
             _ if allow_abstract => None,
             Some(x) => {
-                // Construct and store the error so that the mutable borrow of
-                // self through x ends.
-                let error =
-                    SyntaxError::from(format!("expected variable name or '(', got '{}'", x));
-
-                // self can now be immutably borrowed to get the next location.
-                let err = Err(self.next_location().with(error));
+                let err = Err(Locatable::new(
+                    SyntaxError::from(format!("expected variable name or '(', got '{}'", x)),
+                    self.next_location(),
+                ));
                 self.panic();
                 return err;
             }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -233,7 +233,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         }
         self.next.as_ref().map(|x| &x.data)
     }
-    fn next_location(&mut self) -> Location {
+    fn next_location(&self) -> Location {
         if let Some(token) = &self.current {
             token.location
         } else {

--- a/src/parse/stmt.rs
+++ b/src/parse/stmt.rs
@@ -28,10 +28,9 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         }
         if self.expect(Token::RightBrace).is_err() {
             assert!(self.peek_token().is_none()); // from the 'break' above
-            let actual_err = Locatable::new(
-                SyntaxError::from("unclosed '{' delimeter at end of file"),
-                self.last_location,
-            );
+            let actual_err = self
+                .last_location
+                .with(SyntaxError::from("unclosed '{' delimeter at end of file"));
             pending_errs.push(actual_err);
         }
         if let Some(err) = pending_errs.pop() {
@@ -389,10 +388,9 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
                 None => None,
             },
             None => {
-                return Err(Locatable::new(
-                    SyntaxError::EndOfFile("expression or ';'"),
-                    self.last_location,
-                ));
+                return Err(self
+                    .last_location
+                    .with(SyntaxError::EndOfFile("expression or ';'")));
             }
         };
         let controlling_expr = self


### PR DESCRIPTION
`Location::with` and `Location::error` functions to replace the `Locatable::new` function also used as `CompileError::new`

Fixes #181 