### PR TITLE
fix crash dereferencing no-op

### DIFF
--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1120,7 +1120,8 @@ impl Expr {
                 _ => panic!("only pointers can be dereferenced"),
             },
             ExprType::Member(_, _) => true,
-            _ => unimplemented!("what's an lval but not a pointer or id?"),
+            ExprType::Noop(inner) => inner.is_modifiable_lval(),
+            _ => unimplemented!("what's an lval but not a pointer or id? {}", self),
         }
     }
     // ensure an expression has a value. convert


### PR DESCRIPTION
before, crashes looked like this:

```
Z[--*""];
thread 'main' panicked at 'not yet implemented: what's an lval but not a pointer or id? ""', src/parse/expr.rs:1123:18
```