### PR TITLE
enable color_backtrace in debug mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tempfile = "3"
 pico-args = "0.3"
 string-interner = "0.7"
 codespan = "0.7"
+color-backtrace = { version = "0.3", default-features = false }
 
 [dev-dependencies]
 walkdir = "2"
@@ -32,8 +33,5 @@ walkdir = "2"
 [profile.release]
 lto = true
 
-[profile.dev]
-debug = false  # speeds up link time
-
 [profile.test]
-debug = false
+debug = false  # speeds up link time

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 extern crate ansi_term;
 extern crate codespan;
+#[cfg(debug_assertions)]
+extern crate color_backtrace;
 extern crate env_logger;
 extern crate log;
 extern crate pico_args;
@@ -126,6 +128,9 @@ fn handle_warnings(warnings: VecDeque<CompileWarning>, file: FileId, file_db: &F
 }
 
 fn main() {
+    #[cfg(debug_assertions)]
+    color_backtrace::install();
+
     let mut opt = match parse_args() {
         Ok(opt) => opt,
         Err(err) => {


### PR DESCRIPTION
this makes it looks _so_ much nicer, see [RUST_BACKTRACE=1](https://cdn.discordapp.com/attachments/490356824420122645/672652329971089428/2020-01-30-230003_1920x1080_scrot.png) and [RUST_BACKTRACE=full](https://cdn.discordapp.com/attachments/490356824420122645/672653333718237184/2020-01-30-230401_1920x1080_scrot.png)

r? @pythondude325 