### PR TITLE
Limited errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,10 @@ pub struct Opt {
 
     /// If set, compile and assemble but do not link. Object file is machine-dependent.
     pub no_link: bool,
+
+    /// The maximum number of errors to allow before giving up.
+    /// If None, allows an unlimited number of errors.
+    pub max_errors: Option<std::num::NonZeroUsize>,
 }
 
 impl Default for Opt {
@@ -83,6 +87,7 @@ impl Default for Opt {
             debug_ast: false,
             debug_asm: false,
             no_link: false,
+            max_errors: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 use std::collections::VecDeque;
 use std::fs::File;
 use std::io::{self, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cranelift_module::Backend;
@@ -54,6 +54,36 @@ impl From<CompileError> for Error {
 impl From<VecDeque<CompileError>> for Error {
     fn from(errs: VecDeque<CompileError>) -> Self {
         Error::Source(errs)
+    }
+}
+
+#[derive(Debug)]
+pub struct Opt {
+    /// The file where the C source came from
+    pub filename: PathBuf,
+
+    /// If set, print all tokens found by the lexer in addition to compiling.
+    pub debug_lex: bool,
+
+    /// If set, print the parsed abstract syntax tree in addition to compiling
+    pub debug_ast: bool,
+
+    /// If set, print the intermediate representation of the program in addition to compiling
+    pub debug_asm: bool,
+
+    /// If set, compile and assemble but do not link. Object file is machine-dependent.
+    pub no_link: bool,
+}
+
+impl Default for Opt {
+    fn default() -> Self {
+        Opt {
+            filename: "<default>".into(),
+            debug_lex: false,
+            debug_ast: false,
+            debug_asm: false,
+            no_link: false,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,6 @@ pub fn compile(buf: &str, opt: &Opt) -> (Result<Product, Error>, VecDeque<Compil
             Err(err) => handle_err!(err),
         }
     }
-    //let (hir, parse_errors) = parser.collect_results();
     if hir.is_empty() && errs.is_empty() {
         errs.push_back(eof().error(SemanticError::EmptyProgram));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,13 +67,7 @@ fn real_main(
     output: &Path,
 ) -> Result<(), Error> {
     env_logger::init();
-    let (result, warnings) = compile(
-        file_db.source(file_id),
-        opt.filename.to_string_lossy().into_owned(),
-        opt.debug_lex,
-        opt.debug_ast,
-        opt.debug_asm,
-    );
+    let (result, warnings) = compile(file_db.source(file_id), &opt);
     handle_warnings(warnings, file_id, file_db);
 
     let product = result?;

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -41,13 +41,11 @@ pub fn compile_and_run(program: &str, args: &[&str]) -> Result<Output, Error> {
 }
 
 pub fn compile(program: &str, no_link: bool) -> Result<tempfile::TempPath, Error> {
-    let (result, _warnings) = rcc::compile(
-        program,
-        "<integration-test>".to_string(),
-        false,
-        false,
-        false,
-    );
+    let opts = rcc::Opt {
+        filename: "<integration-test>".into(),
+        ..Default::default()
+    };
+    let (result, _warnings) = rcc::compile(program, &opts);
     let module = result?;
     let output = tempfile::NamedTempFile::new()
         .expect("cannot create tempfile")


### PR DESCRIPTION
Most of the time, people aren't interested in looking at every error at once (especially when forgetting one `{` throws off the rest of the parsing). This only reports a limited number of errors (default: 10) to prevent overwhelming the user.