### PR TITLE
Iterate over bytes instead of characters

### DIFF
--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -119,7 +119,7 @@ pub enum Literal {
     Int(i64),
     UnsignedInt(u64),
     Float(f64),
-    Str(InternedStr),
+    Str(Vec<u8>),
     Char(u8),
 }
 
@@ -351,7 +351,7 @@ impl std::fmt::Display for Literal {
             Int(i) => write!(f, "{}", i),
             UnsignedInt(u) => write!(f, "{}", u),
             Float(n) => write!(f, "{}", n),
-            Str(s) => write!(f, "\"{}\"", s),
+            Str(s) => write!(f, "\"{}\"", String::from_utf8_lossy(s)),
             Char(c) => write!(f, "'{}'", char::from(*c).escape_default()),
         }
     }
@@ -404,7 +404,7 @@ impl From<ComparisonToken> for Token {
 mod test {
     use crate::*;
     fn cpp(s: &str) -> PreProcessor {
-        PreProcessor::new("<integration-test>", s.chars(), false)
+        PreProcessor::new("<integration-test>", s, false)
     }
     #[test]
     fn assignment_display() {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -553,7 +553,7 @@ mod tests {
             "struct s",
         ];
         for ty in types.iter() {
-            let mut lexer = PreProcessor::new("<integration-test>", ty.chars(), false);
+            let mut lexer = PreProcessor::new("<integration-test>", ty, false);
             let first = lexer.next().unwrap().unwrap();
             let mut parser = Parser::new(first, &mut lexer, false);
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -39,7 +39,7 @@ struct Compiler {
     debug: bool,
     // if false, we last saw a switch
     last_saw_loop: bool,
-    strings: HashMap<InternedStr, DataId>,
+    strings: HashMap<Vec<u8>, DataId>,
     loops: Vec<(Block, Block)>,
     // switch, default, end
     // if default is empty once we get to the end of a switch body,

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -36,7 +36,7 @@ use crate::get_str;
 /// use rcc::PreProcessor;
 ///
 /// let cpp = PreProcessor::new("<stdin>".to_string(),
-///                        "int main(void) { char *hello = \"hi\"; }".chars(),
+///                        "int main(void) { char *hello = \"hi\"; }",
 ///                         false);
 /// for token in cpp {
 ///     assert!(token.is_ok());
@@ -97,13 +97,9 @@ impl Iterator for PreProcessor<'_> {
 
 impl<'a> PreProcessor<'a> {
     /// Wrapper around [`Lexer::new`]
-    pub fn new<T: AsRef<str> + Into<String>>(
-        file: T,
-        chars: std::str::Chars<'a>,
-        debug: bool,
-    ) -> Self {
+    pub fn new<T: AsRef<str> + Into<String>>(file: T, chars: &'a str, debug: bool) -> Self {
         Self {
-            lexer: Lexer::new(file, chars),
+            lexer: Lexer::new(file, chars.as_bytes()),
             definitions: Default::default(),
             debug,
             error_handler: Default::default(),
@@ -445,7 +441,7 @@ mod tests {
     use super::{CppResult, Keyword, PreProcessor, KEYWORDS};
     use crate::data::prelude::*;
     fn cpp(input: &str) -> PreProcessor {
-        PreProcessor::new("<test suite>", input.chars(), false)
+        PreProcessor::new("<test suite>", input, false)
     }
     fn assert_keyword(token: Option<CppResult<Token>>, expected: Keyword) {
         match token {

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -1,5 +1,4 @@
 use std::convert::TryFrom;
-use std::str::Chars;
 
 use super::data::{error::LexError, lex::*, prelude::*};
 use super::intern::InternedStr;
@@ -22,11 +21,11 @@ pub use cpp::PreProcessor;
 #[derive(Debug)]
 struct Lexer<'a> {
     location: SingleLocation,
-    chars: Chars<'a>,
+    chars: &'a [u8],
     /// used for 2-character tokens
-    current: Option<char>,
+    current: Option<u8>,
     /// used for 3-character tokens
-    lookahead: Option<char>,
+    lookahead: Option<u8>,
     /// whether we've a token on this line before or not
     /// used for preprocessing (e.g. `#line 5` is a directive
     /// but `int main() { # line 5` is not)
@@ -50,7 +49,7 @@ struct SingleLocation {
 
 impl<'a> Lexer<'a> {
     /// Creates a Lexer from a filename and the contents of a file
-    fn new<T: AsRef<str> + Into<String>>(file: T, chars: Chars<'a>) -> Lexer<'a> {
+    fn new<T: AsRef<str> + Into<String>>(file: T, chars: &'a [u8]) -> Lexer<'a> {
         Lexer {
             location: SingleLocation {
                 offset: 0,
@@ -80,16 +79,16 @@ impl<'a> Lexer<'a> {
     /// Using `chars` will not update location information and may discard lookaheads.
     ///
     /// This function should never set `self.location.offset` to an out-of-bounds location
-    fn next_char(&mut self) -> Option<char> {
+    fn next_char(&mut self) -> Option<u8> {
         let next = if let Some(c) = self.current {
             self.current = self.lookahead.take();
             Some(c)
         } else {
-            self.chars.next()
+            self.chars.get(self.location.offset as usize).copied()
         };
         next.map(|c| {
-            self.location.offset += c.len_utf8() as u32;
-            if c == '\n' {
+            self.location.offset += 1;
+            if c == b'\n' {
                 self.seen_line_token = false;
                 self.line += 1;
             }
@@ -98,20 +97,22 @@ impl<'a> Lexer<'a> {
     }
     /// Return the character that would be returned by `next_char`.
     /// Can be called any number of the times and will still return the same result.
-    fn peek(&mut self) -> Option<char> {
+    fn peek(&mut self) -> Option<u8> {
         self.current = self
             .current
             .or_else(|| self.lookahead.take())
-            .or_else(|| self.chars.next());
+            .or_else(|| self.chars.get(self.location.offset as usize).copied());
         self.current
     }
-    fn peek_next(&mut self) -> Option<char> {
-        self.lookahead = self.lookahead.or_else(|| self.chars.next());
+    fn peek_next(&mut self) -> Option<u8> {
+        self.lookahead = self
+            .lookahead
+            .or_else(|| self.chars.get((self.location.offset + 1) as usize).copied());
         self.lookahead
     }
     /// If the next character is `item`, consume it and return true.
     /// Otherwise, return false.
-    fn match_next(&mut self, item: char) -> bool {
+    fn match_next(&mut self, item: u8) -> bool {
         if self.peek().map_or(false, |c| c == item) {
             self.next_char();
             true
@@ -129,32 +130,32 @@ impl<'a> Lexer<'a> {
     }
     /// Remove all consecutive whitespace pending in the stream.
     ///
-    /// Before: chars{"    hello   "}
+    /// Before: u8s{"    hello   "}
     /// After:  chars{"hello   "}
     fn consume_whitespace(&mut self) {
         while self.peek().map_or(false, |c| c.is_ascii_whitespace()) {
             self.next_char();
         }
     }
-    /// Remove all characters between now and the next '\n' character.
+    /// Remove all characters between now and the next b'\n' character.
     ///
-    /// Before: chars{"blah `invalid tokens``\nhello // blah"}
+    /// Before: u8s{"blah `invalid tokens``\nhello // blah"}
     /// After:  chars{"hello // blah"}
     fn consume_line_comment(&mut self) {
         while let Some(c) = self.next_char() {
-            if c == '\n' {
+            if c == b'\n' {
                 break;
             }
         }
     }
     /// Remove a multi-line C-style comment, i.e. until the next '*/'.
     ///
-    /// Before: chars{"hello this is a lot of text */ int main(){}"}
+    /// Before: u8s{"hello this is a lot of text */ int main(){}"}
     /// After:  chars{" int main(){}"}
     fn consume_multi_comment(&mut self) -> CompileResult<()> {
         let start = self.location.offset - 2;
         while let Some(c) = self.next_char() {
-            if c == '*' && self.peek() == Some('/') {
+            if c == b'*' && self.peek() == Some(b'/') {
                 self.next_char();
                 return Ok(());
             }
@@ -173,24 +174,24 @@ impl<'a> Lexer<'a> {
     /// TODO: return an error enum instead of Strings
     ///
     /// I spent way too much time on this.
-    fn parse_num(&mut self, start: char) -> Result<Token, String> {
-        // start - '0' breaks for hex digits
+    fn parse_num(&mut self, start: u8) -> Result<Token, String> {
+        // start - b'0' breaks for hex digits
         assert!(
-            '0' <= start && start <= '9',
+            b'0' <= start && start <= b'9',
             "main loop should only pass [-.0-9] as start to parse_num"
         );
         let span_start = self.location.offset - 1; // -1 for `start`
         let float_literal = |f| Token::Literal(Literal::Float(f));
         let mut buf = String::new();
-        buf.push(start);
-        // check for radix other than 10 - but if we see '.', use 10
-        let radix = if start == '0' {
-            if self.match_next('b') {
+        buf.push(start as char);
+        // check for radix other than 10 - but if we see b'.', use 10
+        let radix = if start == b'0' {
+            if self.match_next(b'b') {
                 2
-            } else if self.match_next('x') {
+            } else if self.match_next(b'x') {
                 buf.push('x');
                 16
-            } else if self.match_next('.') {
+            } else if self.match_next(b'.') {
                 // float: 0.431
                 return self.parse_float(10, buf).map(float_literal);
             } else {
@@ -200,13 +201,13 @@ impl<'a> Lexer<'a> {
         } else {
             10
         };
-        let start = start as u64 - '0' as u64;
+        let start = start as u64 - b'0' as u64;
 
         // the first {digits} in the regex
         let digits = match self.parse_int(start, radix, &mut buf)? {
             Some(int) => int,
             None => {
-                if radix == 8 || radix == 10 || self.peek() == Some('.') {
+                if radix == 8 || radix == 10 || self.peek() == Some(b'.') {
                     start
                 } else {
                     return Err(format!(
@@ -216,16 +217,16 @@ impl<'a> Lexer<'a> {
                 }
             }
         };
-        if self.match_next('.') {
+        if self.match_next(b'.') {
             return self.parse_float(radix, buf).map(float_literal);
         }
-        if let Some('e') | Some('E') | Some('p') | Some('P') = self.peek() {
+        if let Some(b'e') | Some(b'E') | Some(b'p') | Some(b'P') = self.peek() {
             buf.push_str(".0"); // hexf doesn't like floats without a decimal point
             let float = self.parse_exponent(radix == 16, buf);
             self.consume_float_suffix();
             return float.map(float_literal);
         }
-        let literal = if self.match_next('u') || self.match_next('U') {
+        let literal = if self.match_next(b'u') || self.match_next(b'U') {
             let unsigned = u64::try_from(digits)
                 .map_err(|_| "overflow while parsing unsigned integer literal")?;
             Literal::UnsignedInt(unsigned)
@@ -234,11 +235,11 @@ impl<'a> Lexer<'a> {
                 .map_err(|_| "overflow while parsing signed integer literal")?;
             Literal::Int(long)
         };
-        // get rid of 'l' and 'll' suffixes, we don't handle them
-        if self.match_next('l') {
-            self.match_next('l');
-        } else if self.match_next('L') {
-            self.match_next('L');
+        // get rid of b'l' and 'll' suffixes, we don't handle them
+        if self.match_next(b'l') {
+            self.match_next(b'l');
+        } else if self.match_next(b'L') {
+            self.match_next(b'L');
         }
         if radix == 2 {
             let span = self.span(span_start);
@@ -252,6 +253,7 @@ impl<'a> Lexer<'a> {
         buf.push('.');
         // parse fraction: second {digits} in regex
         while let Some(c) = self.peek() {
+            let c = c as char;
             if c.is_digit(radix) {
                 self.next_char();
                 buf.push(c);
@@ -261,38 +263,42 @@ impl<'a> Lexer<'a> {
         }
         // in case of an empty mantissa, hexf doesn't like having the exponent right after the .
         // if the mantissa isn't empty, .12 is the same as .120
-        //buf.push('0');
+        //buf.push(b'0');
         let float = self.parse_exponent(radix == 16, buf);
         self.consume_float_suffix();
         float
     }
     fn consume_float_suffix(&mut self) {
         // Ignored for compatibility reasons
-        if !(self.match_next('f') || self.match_next('F') || self.match_next('l')) {
-            self.match_next('L');
+        if !(self.match_next(b'f') || self.match_next(b'F') || self.match_next(b'l')) {
+            self.match_next(b'L');
         }
     }
     // should only be called at the end of a number. mostly error handling
     fn parse_exponent(&mut self, hex: bool, mut buf: String) -> Result<f64, String> {
-        let is_digit =
-            |c: Option<char>| c.map_or(false, |c| c.is_digit(10) || c == '+' || c == '-');
+        let is_digit = |c: Option<u8>| {
+            c.map_or(false, |c| {
+                (c as char).is_digit(10) || c == b'+' || c == b'-'
+            })
+        };
         if hex {
-            if self.match_next('p') || self.match_next('P') {
+            if self.match_next(b'p') || self.match_next(b'P') {
                 if !is_digit(self.peek()) {
                     return Err(String::from("exponent for floating literal has no digits"));
                 }
                 buf.push('p');
-                buf.push(self.next_char().unwrap());
+                buf.push(self.next_char().unwrap() as char);
             }
-        } else if self.match_next('e') || self.match_next('E') {
+        } else if self.match_next(b'e') || self.match_next(b'E') {
             if !is_digit(self.peek()) {
                 return Err(String::from("exponent for floating literal has no digits"));
             }
             buf.push('e');
-            buf.push(self.next_char().unwrap());
+            buf.push(self.next_char().unwrap() as char);
         }
         while let Some(c) = self.peek() {
-            if !c.is_digit(10) {
+            let c = c as char;
+            if !(c).is_digit(10) {
                 break;
             }
             buf.push(c);
@@ -307,8 +313,8 @@ impl<'a> Lexer<'a> {
         if float.is_infinite() {
             return Err("overflow parsing floating literal".into());
         }
-        let should_be_zero = buf.chars().all(|c| match c {
-            '.' | '+' | '-' | 'e' | 'p' | '0' => true,
+        let should_be_zero = buf.bytes().all(|c| match c {
+            b'.' | b'+' | b'-' | b'e' | b'p' | b'0' => true,
             _ => false,
         });
         if float == 0.0 && !should_be_zero {
@@ -327,9 +333,9 @@ impl<'a> Lexer<'a> {
         let parse_digit = |c: char| match c.to_digit(16) {
             None => Ok(None),
             Some(digit) if digit < radix => Ok(Some(digit)),
-            // if we see 'e' or 'E', it's the end of the int, don't treat it as an error
-            // if we see 'b' this could be part of a binary constant (0b1)
-            // if we see 'f' it could be a float suffix
+            // if we see b'e' or b'E', it's the end of the int, don't treat it as an error
+            // if we see b'b' this could be part of a binary constant (0b1)
+            // if we see b'f' it could be a float suffix
             // we only get this far if it's not a valid digit for the radix, i.e. radix != 16
             Some(11) | Some(14) | Some(15) => Ok(None),
             Some(digit) => Err(format!(
@@ -354,7 +360,7 @@ impl<'a> Lexer<'a> {
                 self.next_char();
                 continue;
             }
-            let digit = match parse_digit(c)? {
+            let digit = match parse_digit(c as char)? {
                 Some(d) => {
                     self.next_char();
                     saw_digit = true;
@@ -364,7 +370,7 @@ impl<'a> Lexer<'a> {
                     break;
                 }
             };
-            buf.push(c);
+            buf.push(c as char);
             let maybe_digits = acc
                 .checked_mul(radix.into())
                 .and_then(|a| a.checked_add(digit.into()));
@@ -385,29 +391,29 @@ impl<'a> Lexer<'a> {
     ///
     /// Has a side effect: will call `warn` if it sees an invalid escape.
     ///
-    /// Before: chars{"\b'"}
+    /// Before: u8s{"\b'"}
     /// After:  chars{"'"}
-    fn parse_single_char(&mut self, string: bool) -> Result<char, CharError> {
-        let terminator = if string { '"' } else { '\'' };
+    fn parse_single_char(&mut self, string: bool) -> Result<u8, CharError> {
+        let terminator = if string { b'"' } else { b'\'' };
         if let Some(c) = self.next_char() {
-            if c == '\\' {
+            if c == b'\\' {
                 if let Some(c) = self.next_char() {
                     Ok(match c {
                         // escaped newline: "a\
                         // b"
-                        '\n' => return self.parse_single_char(string),
-                        'n' => '\n',   // embedded newline: "a\nb"
-                        'r' => '\r',   // carriage return
-                        't' => '\t',   // tab
-                        '"' => '"',    // escaped "
-                        '\'' => '\'',  // escaped '
-                        '\\' => '\\',  // \
-                        '0' => '\0',   // null character: "\0"
-                        'a' => '\x07', // bell
-                        'b' => '\x08', // backspace
-                        'v' => '\x0b', // vertical tab
-                        'f' => '\x0c', // form feed
-                        '?' => '?',    // a literal '?', for trigraphs
+                        b'\n' => return self.parse_single_char(string),
+                        b'n' => b'\n',   // embedded newline: "a\nb"
+                        b'r' => b'\r',   // carriage return
+                        b't' => b'\t',   // tab
+                        b'"' => b'"',    // escaped "
+                        b'\'' => b'\'',  // escaped '
+                        b'\\' => b'\\',  // \
+                        b'0' => b'\0',   // null character: "\0"
+                        b'a' => b'\x07', // bell
+                        b'b' => b'\x08', // backspace
+                        b'v' => b'\x0b', // vertical tab
+                        b'f' => b'\x0c', // form feed
+                        b'?' => b'?',    // a literal b'?', for trigraphs
                         _ => {
                             self.error_handler.warn(
                                 &format!("unknown character escape '\\{}'", c),
@@ -419,7 +425,7 @@ impl<'a> Lexer<'a> {
                 } else {
                     Err(CharError::Eof)
                 }
-            } else if c == '\n' {
+            } else if c == b'\n' {
                 Err(CharError::Newline)
             } else if c == terminator {
                 Err(CharError::Terminator)
@@ -438,7 +444,7 @@ impl<'a> Lexer<'a> {
         fn consume_until_quote(lexer: &mut Lexer) {
             loop {
                 match lexer.parse_single_char(false) {
-                    Ok('\'') => break,
+                    Ok(b'\'') => break,
                     Err(_) => break,
                     _ => {}
                 }
@@ -452,8 +458,8 @@ impl<'a> Lexer<'a> {
         );
         match self.parse_single_char(false) {
             Ok(c) if c.is_ascii() => match self.next_char() {
-                Some('\'') => Ok(Literal::Char(c as u8).into()),
-                Some('\n') => newline_err,
+                Some(b'\'') => Ok(Literal::Char(c as u8).into()),
+                Some(b'\n') => newline_err,
                 None => term_err,
                 Some(_) => {
                     consume_until_quote(self);
@@ -474,12 +480,12 @@ impl<'a> Lexer<'a> {
     /// Concatenates multiple adjacent literals into one string.
     /// Adds a terminating null character, even if a null character has already been found.
     ///
-    /// Before: chars{"hello" "you" "it's me" mary}
+    /// Before: u8s{"hello" "you" "it's me" mary}
     /// After:  chars{mary}
     fn parse_string(&mut self) -> Result<Token, String> {
-        let mut literal = String::new();
+        let mut literal = Vec::new();
         // allow multiple adjacent strings
-        while self.peek() == Some('"') {
+        while self.peek() == Some(b'"') {
             self.next_char(); // start quote
             loop {
                 match self.parse_single_char(true) {
@@ -497,21 +503,22 @@ impl<'a> Lexer<'a> {
             }
             self.consume_whitespace();
         }
-        literal.push('\0');
-        Ok(Literal::Str(InternedStr::get_or_intern(literal)).into())
+        literal.push(b'\0');
+        Ok(Literal::Str(literal).into())
     }
     /// Parse an identifier or keyword, given the starting letter.
     ///
     /// Identifiers match the following regex: `[a-zA-Z_][a-zA-Z0-9_]*`
-    fn parse_id(&mut self, start: char) -> Result<Token, String> {
+    fn parse_id(&mut self, start: u8) -> Result<Token, String> {
         let mut id = String::new();
-        id.push(start);
+        id.push(start.into());
         while let Some(c) = self.peek() {
-            if c.is_digit(10) || 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_' {
-                self.next_char();
-                id.push(c);
-            } else {
-                break;
+            match c {
+                b'0'..=b'9' | b'a'..=b'z' | b'A'..=b'Z' | b'_' => {
+                    self.next_char();
+                    id.push(c.into());
+                }
+                _ => break,
             }
         }
         Ok(Token::Id(InternedStr::get_or_intern(id)))
@@ -534,20 +541,20 @@ impl<'a> Iterator for Lexer<'a> {
         self.consume_whitespace();
         let mut c = self.next_char();
         // Section 5.1.1.2 phase 2: discard backslashes before newlines
-        while c == Some('\\') && self.match_next('\n') {
+        while c == Some(b'\\') && self.match_next(b'\n') {
             self.consume_whitespace();
             c = self.next_char();
         }
         // avoid stack overflow on lots of comments
-        while c == Some('/') {
+        while c == Some(b'/') {
             c = match self.peek() {
-                Some('/') => {
+                Some(b'/') => {
                     self.consume_line_comment();
                     self.consume_whitespace();
                     self.next_char()
                 }
-                Some('*') => {
-                    // discard '*' so /*/ doesn't look like a complete comment
+                Some(b'*') => {
+                    // discard b'*' so /*/ doesn't look like a complete comment
                     self.next_char();
                     if let Err(err) = self.consume_multi_comment() {
                         return Some(Err(err));
@@ -559,86 +566,86 @@ impl<'a> Iterator for Lexer<'a> {
             }
         }
         let c = c.and_then(|c| {
-            let span_start = self.location.offset - c.len_utf8() as u32;
+            let span_start = self.location.offset - 1;
             // this giant switch is most of the logic
             let data = match c {
-                '#' => Token::Hash,
-                '+' => match self.peek() {
-                    Some('=') => {
+                b'#' => Token::Hash,
+                b'+' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::PlusEqual.into()
                     }
-                    Some('+') => {
+                    Some(b'+') => {
                         self.next_char();
                         Token::PlusPlus
                     }
                     _ => Token::Plus,
                 },
-                '-' => match self.peek() {
-                    Some('=') => {
+                b'-' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::MinusEqual.into()
                     }
-                    Some('-') => {
+                    Some(b'-') => {
                         self.next_char();
                         Token::MinusMinus
                     }
-                    Some('>') => {
+                    Some(b'>') => {
                         self.next_char();
                         Token::StructDeref
                     }
                     _ => Token::Minus,
                 },
-                '*' => match self.peek() {
-                    Some('=') => {
+                b'*' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::StarEqual.into()
                     }
                     _ => Token::Star,
                 },
-                '/' => {
-                    if self.match_next('=') {
+                b'/' => {
+                    if self.match_next(b'=') {
                         AssignmentToken::DivideEqual.into()
                     } else {
                         Token::Divide
                     }
                 }
-                '%' => match self.peek() {
-                    Some('=') => {
+                b'%' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::ModEqual.into()
                     }
                     _ => Token::Mod,
                 },
-                '^' => {
-                    if self.match_next('=') {
+                b'^' => {
+                    if self.match_next(b'=') {
                         AssignmentToken::XorEqual.into()
                     } else {
                         Token::Xor
                     }
                 }
-                '=' => match self.peek() {
-                    Some('=') => {
+                b'=' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         ComparisonToken::EqualEqual.into()
                     }
                     _ => Token::EQUAL,
                 },
-                '!' => match self.peek() {
-                    Some('=') => {
+                b'!' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         ComparisonToken::NotEqual.into()
                     }
                     _ => Token::LogicalNot,
                 },
-                '>' => match self.peek() {
-                    Some('=') => {
+                b'>' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         ComparisonToken::GreaterEqual.into()
                     }
-                    Some('>') => {
+                    Some(b'>') => {
                         self.next_char();
-                        if self.match_next('=') {
+                        if self.match_next(b'=') {
                             AssignmentToken::RightEqual.into()
                         } else {
                             Token::ShiftRight
@@ -646,14 +653,14 @@ impl<'a> Iterator for Lexer<'a> {
                     }
                     _ => ComparisonToken::Greater.into(),
                 },
-                '<' => match self.peek() {
-                    Some('=') => {
+                b'<' => match self.peek() {
+                    Some(b'=') => {
                         self.next_char();
                         ComparisonToken::LessEqual.into()
                     }
-                    Some('<') => {
+                    Some(b'<') => {
                         self.next_char();
-                        if self.match_next('=') {
+                        if self.match_next(b'=') {
                             AssignmentToken::LeftEqual.into()
                         } else {
                             Token::ShiftLeft
@@ -661,39 +668,39 @@ impl<'a> Iterator for Lexer<'a> {
                     }
                     _ => ComparisonToken::Less.into(),
                 },
-                '&' => match self.peek() {
-                    Some('&') => {
+                b'&' => match self.peek() {
+                    Some(b'&') => {
                         self.next_char();
                         Token::LogicalAnd
                     }
-                    Some('=') => {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::AndEqual.into()
                     }
                     _ => Token::Ampersand,
                 },
-                '|' => match self.peek() {
-                    Some('|') => {
+                b'|' => match self.peek() {
+                    Some(b'|') => {
                         self.next_char();
                         Token::LogicalOr
                     }
-                    Some('=') => {
+                    Some(b'=') => {
                         self.next_char();
                         AssignmentToken::OrEqual.into()
                     }
                     _ => Token::BitwiseOr,
                 },
-                '{' => Token::LeftBrace,
-                '}' => Token::RightBrace,
-                '(' => Token::LeftParen,
-                ')' => Token::RightParen,
-                '[' => Token::LeftBracket,
-                ']' => Token::RightBracket,
-                '~' => Token::BinaryNot,
-                ':' => Token::Colon,
-                ';' => Token::Semicolon,
-                ',' => Token::Comma,
-                '.' => match self.peek() {
+                b'{' => Token::LeftBrace,
+                b'}' => Token::RightBrace,
+                b'(' => Token::LeftParen,
+                b')' => Token::RightParen,
+                b'[' => Token::LeftBracket,
+                b']' => Token::RightBracket,
+                b'~' => Token::BinaryNot,
+                b':' => Token::Colon,
+                b';' => Token::Semicolon,
+                b',' => Token::Comma,
+                b'.' => match self.peek() {
                     Some(c) if c.is_ascii_digit() => match self.parse_float(10, String::new()) {
                         Ok(f) => Literal::Float(f).into(),
                         Err(err) => {
@@ -703,8 +710,8 @@ impl<'a> Iterator for Lexer<'a> {
                             }))
                         }
                     },
-                    Some('.') => {
-                        if self.peek_next() == Some('.') {
+                    Some(b'.') => {
+                        if self.peek_next() == Some(b'.') {
                             self.next_char();
                             self.next_char();
                             Token::Ellipsis
@@ -714,30 +721,30 @@ impl<'a> Iterator for Lexer<'a> {
                     }
                     _ => Token::Dot,
                 },
-                '?' => Token::Question,
-                '0'..='9' => match self.parse_num(c) {
+                b'?' => Token::Question,
+                b'0'..=b'9' => match self.parse_num(c) {
                     Ok(num) => num,
                     Err(err) => {
                         let span = self.span(span_start);
                         return Some(Err(span.with(err)));
                     }
                 },
-                'a'..='z' | 'A'..='Z' | '_' => match self.parse_id(c) {
+                b'a'..=b'z' | b'A'..=b'Z' | b'_' => match self.parse_id(c) {
                     Ok(id) => id,
                     Err(err) => {
                         let span = self.span(span_start);
                         return Some(Err(span.with(err)));
                     }
                 },
-                '\'' => match self.parse_char() {
+                b'\'' => match self.parse_char() {
                     Ok(id) => id,
                     Err(err) => {
                         let span = self.span(span_start);
                         return Some(Err(span.with(err)));
                     }
                 },
-                '"' => {
-                    self.current = Some('"');
+                b'"' => {
+                    self.current = Some(b'"');
                     self.location.offset -= 1;
                     match self.parse_string() {
                         Ok(id) => id,

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -14,7 +14,7 @@ fn lex(input: &str) -> Option<LexType> {
     lexed.pop()
 }
 fn lex_all(input: &str) -> Vec<LexType> {
-    Lexer::new("<test suite>".to_string(), input.chars()).collect()
+    Lexer::new("<test suite>".to_string(), input.as_bytes()).collect()
 }
 
 fn match_data<T>(lexed: Option<LexType>, closure: T) -> bool
@@ -39,7 +39,7 @@ fn match_char(lexed: Option<LexType>, expected: u8) -> bool {
 }
 
 fn match_str(lexed: Option<LexType>, expected: &str) -> bool {
-    let string = InternedStr::get_or_intern(format!("{}\0", expected));
+    let string = format!("{}\0", expected).into();
     match_data(lexed, |c| c == Ok(&Literal::Str(string).into()))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ impl Default for Opt {
 pub fn compile(buf: &str, opt: &Opt) -> (Result<Product, Error>, VecDeque<CompileWarning>) {
     let filename = opt.filename.to_string_lossy();
     let filename_ref = InternedStr::get_or_intern(filename.as_ref());
-    let mut cpp = PreProcessor::new(filename, buf.chars(), opt.debug_lex);
+    let mut cpp = PreProcessor::new(filename, &buf, opt.debug_lex);
 
     let mut errs = VecDeque::new();
 

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1522,7 +1522,7 @@ impl Expr {
 
 impl From<(Literal, Location)> for Expr {
     fn from((literal, location): (Literal, Location)) -> Self {
-        let ctype = match literal {
+        let ctype = match &literal {
             Literal::Char(_) => Type::Char(true),
             Literal::Int(_) => Type::Long(true),
             Literal::UnsignedInt(_) => Type::Long(false),
@@ -1737,7 +1737,7 @@ pub(crate) mod tests {
         assert_eq!(
             parsed,
             Ok(Expr::from((
-                Literal::Str(InternedStr::get_or_intern("hi there\0")),
+                Literal::Str("hi there\0".into()),
                 get_location(&parsed)
             )))
         );

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -446,7 +446,7 @@ pub(crate) mod tests {
     }
     #[inline]
     pub(crate) fn parser(input: &str) -> Parser<Lexer> {
-        let mut lexer = Lexer::new("<test suite>".to_string(), input.chars(), false);
+        let mut lexer = Lexer::new("<test suite>".to_string(), input, false);
         let first = lexer.next().unwrap().unwrap();
         Parser::new(first, lexer, false)
     }

--- a/tests/runner-tests/io.c
+++ b/tests/runner-tests/io.c
@@ -1,0 +1,13 @@
+// output: BEGIN:
+// hi
+// hello
+// hi
+// END
+int puts(const char*);
+int *s1 = "hi", *s2 = "hello", *s3 = "hi";
+
+int main() {
+	puts(s1);
+	puts(s2);
+	puts(s3);
+}


### PR DESCRIPTION
The goal here is to
a) make the lexer much faster, since it doesn't need to find the character boundaries at every point and
b) make `lexer.chars` much easier to work with, since it now it can be a `Cow<u8>` (left for a future PR).

This also turns Literal::Str into arbitrary bytes. Note that `string-interner` does not work with `Vec<u8>` and so strings can't be interned; however, since Str is only used when writing it into the binary, this has no effect on performance (it just needed me to juggle around the `compile_string()` function).