### PR TITLE
Remove unused code

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -eu
-rm -f target/debug/*-*
-RUSTFLAGS='-C debuginfo=2' cargo test --no-run
-ls -1 target/debug/*-* \
-	| grep -v '\.d$' \
-	| xargs -n1 kcov --verify target/cov
-xdg-open target/cov/index.html

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -21,15 +21,15 @@ use Type::*;
 const CHAR_SIZE: u16 = 1;
 
 // TODO: allow this to be configured at runtime
-pub const TARGET: Triple = Triple::host();
+pub(crate) const TARGET: Triple = Triple::host();
 // TODO: make this const when const_if_match is stabilized
 // TODO: see https://github.com/rust-lang/rust/issues/49146
 lazy_static! {
-    pub static ref CALLING_CONVENTION: CallConv = CallConv::triple_default(&TARGET);
+    pub(crate) static ref CALLING_CONVENTION: CallConv = CallConv::triple_default(&TARGET);
 }
 
 mod x64;
-pub use x64::*;
+pub(crate) use x64::*;
 
 impl StructType {
     /// Get the offset of the given struct member.

--- a/src/arch/x64.rs
+++ b/src/arch/x64.rs
@@ -1,17 +1,17 @@
 // https://en.wikipedia.org/wiki/64-bit_computing#64-bit_data_models
 #[allow(non_camel_case_types)]
-pub type SIZE_T = u64;
+pub(crate) type SIZE_T = u64;
 #[allow(dead_code)]
-pub const SIZE_MAX: SIZE_T = SIZE_T::max_value();
+pub(crate) const SIZE_MAX: SIZE_T = SIZE_T::max_value();
 
-pub const FLOAT_SIZE: u16 = 4;
-pub const DOUBLE_SIZE: u16 = 8;
+pub(crate) const FLOAT_SIZE: u16 = 4;
+pub(crate) const DOUBLE_SIZE: u16 = 8;
 
-pub const LONG_SIZE: u16 = 8;
-pub const INT_SIZE: u16 = 4;
-pub const SHORT_SIZE: u16 = 2;
-pub const BOOL_SIZE: u16 = 1;
+pub(crate) const LONG_SIZE: u16 = 8;
+pub(crate) const INT_SIZE: u16 = 4;
+pub(crate) const SHORT_SIZE: u16 = 2;
+pub(crate) const BOOL_SIZE: u16 = 1;
 
-pub const PTR_SIZE: u16 = 8;
+pub(crate) const PTR_SIZE: u16 = 8;
 
-pub const CHAR_BIT: u16 = 8; // number of bits in a byte
+pub(crate) const CHAR_BIT: u16 = 8; // number of bits in a byte

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -179,18 +179,6 @@ impl Qualifiers {
     };
 }
 
-impl Expr {
-    pub fn zero(location: Location) -> Expr {
-        Expr {
-            ctype: Type::Int(true),
-            constexpr: true,
-            expr: ExprType::Literal(Literal::Int(0)),
-            lval: false,
-            location,
-        }
-    }
-}
-
 impl<K: Hash + Eq, V> Scope<K, V> {
     #[inline]
     pub fn new() -> Self {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -291,7 +291,7 @@ impl<K: Hash + Eq, V> Scope<K, V> {
     pub fn is_global(&self) -> bool {
         self.0.len() == 1
     }
-    pub fn _remove(&mut self, key: &K) -> Option<V> {
+    pub(crate) fn _remove(&mut self, key: &K) -> Option<V> {
         debug_assert!(!self.0.is_empty());
         self.0.last_mut().unwrap().remove(key)
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -67,15 +67,6 @@ pub enum Initializer {
     FunctionBody(Vec<Stmt>),           // int f() { return 0; }
 }
 
-impl Initializer {
-    pub fn is_scalar(&self) -> bool {
-        match self {
-            Self::Scalar(_) => true,
-            _ => false,
-        }
-    }
-}
-
 /// Holds the metadata for an expression.
 ///
 /// This should be the datatype you use in APIs, etc.
@@ -177,26 +168,15 @@ pub struct Qualifiers {
 #[derive(Debug)]
 pub struct Scope<K: Hash + Eq, V>(Vec<HashMap<K, V>>);
 
-#[allow(dead_code)]
 impl Qualifiers {
-    pub const NONE: Qualifiers = Qualifiers {
+    pub(crate) const NONE: Qualifiers = Qualifiers {
         c_const: false,
         volatile: false,
         inline: false,
     };
-    pub const VOLATILE: Qualifiers = Qualifiers {
-        c_const: false,
-        volatile: true,
-        inline: false,
-    };
-    pub const CONST: Qualifiers = Qualifiers {
+    pub(crate) const CONST: Qualifiers = Qualifiers {
         c_const: true,
         volatile: false,
-        inline: false,
-    };
-    pub const CONST_VOLATILE: Qualifiers = Qualifiers {
-        c_const: true,
-        volatile: true,
         inline: false,
     };
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -164,7 +164,7 @@ pub struct Qualifiers {
 }
 
 #[derive(Debug)]
-pub struct Scope<K: Hash + Eq, V>(Vec<HashMap<K, V>>);
+pub(crate) struct Scope<K: Hash + Eq, V>(Vec<HashMap<K, V>>);
 
 impl Qualifiers {
     pub(crate) const NONE: Qualifiers = Qualifiers {
@@ -181,43 +181,43 @@ impl Qualifiers {
 
 impl<K: Hash + Eq, V> Scope<K, V> {
     #[inline]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self(vec![HashMap::new()])
     }
     #[inline]
-    pub fn enter_scope(&mut self) {
+    pub(crate) fn enter_scope(&mut self) {
         self.0.push(HashMap::<K, V>::new())
     }
     #[inline]
-    pub fn leave_scope(&mut self) {
+    pub(crate) fn leave_scope(&mut self) {
         self.0.pop();
     }
-    pub fn get(&self, name: &K) -> Option<&V> {
+    pub(crate) fn get(&self, name: &K) -> Option<&V> {
         self.iter()
             .filter_map(|(key, value)| if key == name { Some(value) } else { None })
             .next()
     }
     // returns whether the _immediate_ scope contains `name`
     #[inline]
-    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+    pub(crate) fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.0.last_mut().unwrap().insert(key, value)
     }
     #[inline]
-    pub fn get_immediate(&self, name: &K) -> Option<&V> {
+    pub(crate) fn get_immediate(&self, name: &K) -> Option<&V> {
         self.0.last().unwrap().get(name)
     }
     #[inline]
-    pub fn get_all_immediate(&mut self) -> &mut HashMap<K, V> {
+    pub(crate) fn get_all_immediate(&mut self) -> &mut HashMap<K, V> {
         self.0.last_mut().unwrap()
     }
-    pub fn is_global(&self) -> bool {
+    pub(crate) fn is_global(&self) -> bool {
         self.0.len() == 1
     }
     pub(crate) fn _remove(&mut self, key: &K) -> Option<V> {
         debug_assert!(!self.0.is_empty());
         self.0.last_mut().unwrap().remove(key)
     }
-    pub fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&K, &V)> {
         self.0.iter().rev().flatten()
     }
 }

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -63,24 +63,13 @@ macro_rules! fold_compare_op {
 }
 
 impl Expr {
-    pub fn is_zero(&self) -> bool {
+    pub(crate) fn is_zero(&self) -> bool {
         if let ExprType::Literal(token) = &self.expr {
             match *token {
                 Int(i) => i == 0,
                 UnsignedInt(u) => u == 0,
                 Float(f) => f == 0.0,
                 Char(c) => c == 0,
-                _ => false,
-            }
-        } else {
-            false
-        }
-    }
-    pub fn is_negative(&self) -> bool {
-        if let ExprType::Literal(token) = &self.expr {
-            match *token {
-                Int(i) => i < 0,
-                Float(f) => f < 0.0,
                 _ => false,
             }
         } else {

--- a/src/fold.rs
+++ b/src/fold.rs
@@ -76,9 +76,7 @@ impl Expr {
             false
         }
     }
-    // first result: whether the expression itself is erroneous
-    // second result: whether the expression was constexpr
-    pub fn constexpr(self) -> CompileResult<Locatable<(Literal, Type)>> {
+    pub(crate) fn constexpr(self) -> CompileResult<Locatable<(Literal, Type)>> {
         let folded = self.const_fold()?;
         match folded.expr {
             ExprType::Literal(token) => Ok(Locatable {

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::sync::RwLock;
 
 use lazy_static::lazy_static;
-use string_interner::{StringInterner, Sym, Symbol};
+use string_interner::{StringInterner, Sym};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InternedStr(pub Sym);
@@ -25,16 +25,6 @@ macro_rules! get_str {
 }
 
 impl InternedStr {
-    #[inline(always)]
-    pub fn to_usize(self) -> usize {
-        self.0.to_usize()
-    }
-    pub fn len(self) -> usize {
-        get_str!(self).len()
-    }
-    pub fn is_empty(self) -> bool {
-        self == Default::default()
-    }
     pub fn resolve_and_clone(self) -> String {
         get_str!(self).to_string()
     }

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -12,8 +12,8 @@ use crate::data::{
 type IrResult = CompileResult<Value>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Value {
-    pub(crate) ir_val: IrValue,
+pub(super) struct Value {
+    pub(super) ir_val: IrValue,
     ir_type: IrType,
     ctype: Type,
 }
@@ -27,7 +27,7 @@ impl Compiler {
     // clippy doesn't like big match statements, but this is kind of essential complexity,
     // it can't be any smaller without supporting fewer features
     #[allow(clippy::cognitive_complexity)]
-    pub(crate) fn compile_expr(&mut self, expr: Expr, builder: &mut FunctionBuilder) -> IrResult {
+    pub(super) fn compile_expr(&mut self, expr: Expr, builder: &mut FunctionBuilder) -> IrResult {
         let expr = expr.const_fold()?;
         let location = expr.location;
         let ir_type = if expr.lval {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -361,3 +361,9 @@ impl Compiler {
         Ok(())
     }
 }
+
+impl FunctionType {
+    fn has_params(&self) -> bool {
+        !(self.params.len() == 1 && self.params[0].ctype == Type::Void)
+    }
+}

--- a/src/ir/static_init.rs
+++ b/src/ir/static_init.rs
@@ -15,7 +15,7 @@ const_assert!(PTR_SIZE <= std::usize::MAX as u16);
 const ZERO_PTR: [u8; PTR_SIZE as usize] = [0; PTR_SIZE as usize];
 
 impl Compiler {
-    pub(crate) fn store_static(
+    pub(super) fn store_static(
         &mut self,
         mut symbol: Symbol,
         init: Option<Initializer>,
@@ -100,7 +100,7 @@ impl Compiler {
             })
         })
     }
-    pub(crate) fn compile_string(
+    pub(super) fn compile_string(
         &mut self,
         string: Vec<u8>,
         location: Location,

--- a/src/ir/stmt.rs
+++ b/src/ir/stmt.rs
@@ -6,7 +6,7 @@ use super::Compiler;
 use crate::data::prelude::*;
 
 impl Compiler {
-    pub(crate) fn compile_all(
+    pub(super) fn compile_all(
         &mut self,
         stmts: Vec<Stmt>,
         builder: &mut FunctionBuilder,
@@ -16,7 +16,7 @@ impl Compiler {
         }
         Ok(())
     }
-    pub(crate) fn compile_stmt(
+    pub(super) fn compile_stmt(
         &mut self,
         stmt: Stmt,
         builder: &mut FunctionBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use parse::Parser;
 
 #[macro_use]
 pub mod utils;
-pub mod arch;
+mod arch;
 pub mod data;
 mod fold;
 pub mod intern;

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ fn error<T: std::fmt::Display>(msg: T, location: Location, file: FileId, file_db
 }
 
 #[must_use]
-pub fn pretty_print<T: std::fmt::Display, S: AsRef<str>>(
+fn pretty_print<T: std::fmt::Display, S: AsRef<str>>(
     prefix: ANSIString,
     msg: T,
     location: Location,

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -29,7 +29,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
     /// where specifier_qualifier_list: (type_specifier | type_qualifier)+
     ///
     /// Used for casts and `sizeof` builtin.
-    pub fn type_name(&mut self) -> SyntaxResult<Locatable<(Type, Qualifiers)>> {
+    pub(crate) fn type_name(&mut self) -> SyntaxResult<Locatable<(Type, Qualifiers)>> {
         let (sc, qualifiers, ctype, _) = self.declaration_specifiers()?;
         if sc != None {
             self.semantic_err("type cannot have a storage class", self.last_location);
@@ -64,7 +64,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
      * We push all but one declaration into the 'pending' vector
      * and return the last.
      */
-    pub fn declaration(&mut self) -> SyntaxResult<VecDeque<Locatable<Declaration>>> {
+    pub(super) fn declaration(&mut self) -> SyntaxResult<VecDeque<Locatable<Declaration>>> {
         let (sc, mut qualifiers, ctype, seen_compound_type) = self.declaration_specifiers()?;
         if self.match_next(&Token::Semicolon).is_some() {
             if !seen_compound_type {

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1739,6 +1739,13 @@ impl Declarator {
 }
 
 impl Type {
+    #[inline]
+    fn is_char(&self) -> bool {
+        match self {
+            Type::Char(true) => true,
+            _ => false,
+        }
+    }
     /// Given a type, return the maximum number of initializers for that type
     fn type_len(&self) -> usize {
         match self {

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1703,7 +1703,7 @@ impl Type {
     /// It is an error to take the rank of a non-integral type.
     ///
     /// Examples:
-    /// ```
+    /// ```ignore
     /// use rcc::data::types::Type::*;
     /// assert!(Long(true).rank() > Int(true).rank());
     /// assert!(Int(false).rank() > Short(false).rank());

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -1114,6 +1114,16 @@ impl Token {
 
 /* stateless helper functions */
 impl Expr {
+    fn zero(location: Location) -> Expr {
+        Expr {
+            ctype: Type::Int(true),
+            constexpr: true,
+            expr: ExprType::Literal(Literal::Int(0)),
+            lval: false,
+            location,
+        }
+    }
+
     fn indirection(self, lval: bool, ctype: Type, location: Location) -> Self {
         Expr {
             constexpr: self.constexpr,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use std::process;
 
 use ansi_term::Colour;
 
+// TODO: this should only be the binary, not the library
 pub fn fatal<T: std::fmt::Display>(msg: T, code: i32) -> ! {
     eprintln!("{}: {}", Colour::Black.bold().paint("fatal"), msg);
     process::exit(code);


### PR DESCRIPTION
Removed altogether:
- LengthError::{Unbounded, Dynamic}
- Initializer::is_scalar
- Expr::is_negative
- InternedStr::{to_usize, len, is_empty}
- Qualifiers::{VOLATILE, CONST_VOLATILE}
- `./coverage.sh`

Renamed:
- data::{LengthError, Expr::const_int, Type::is_char} -> decl
- data::{Expr::zero, Type::{is_void_pointer, is_char_pointer, is_pointer_to_complete_object, is_struct, is_complete}} -> expr
- data::FunctionType::has_params -> ir