### PR TITLE
Allow using `Source` without a filepath

### DIFF
--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -992,7 +992,7 @@ impl<'a> PreProcessor<'a> {
             let current_path = &self.files.source(self.lexer().location.file).path;
             let relative_path = &current_path
                 .parent()
-                .expect("current file can't be a directory");
+                .unwrap_or_else(|| std::path::Path::new(""));
             let resolved = relative_path.join(&filename);
             if resolved.exists() {
                 return Ok(resolved);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,11 @@ use cranelift_object::ObjectBackend;
 /// The `Source` type for `codespan::Files`.
 ///
 /// Used to store extra metadata about the file, like the absolute filename.
+///
+/// NOTE: If `path` is empty (e.g. by using `my_string.into()`),
+/// then the path will be relative to the _compiler_, not to the current file.
+/// This is recommended only for test code and proof of concepts,
+/// since it does not adhere to the C standard.
 pub struct Source {
     pub code: Rc<str>,
     pub path: PathBuf,
@@ -225,7 +230,6 @@ pub fn link(obj_file: &Path, output: &Path) -> Result<(), io::Error> {
     }
 }
 
-#[cfg(test)]
 impl<T: Into<Rc<str>>> From<T> for Source {
     fn from(src: T) -> Self {
         Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,7 +350,7 @@ mod test {
 
     fn pp<S: Into<Span>>(span: S, source: &str) -> String {
         let mut file_db = Files::new();
-        let source = String::from(source).into());
+        let source = String::from(source).into();
         let file = file_db.add("<test-suite>", source);
         let location = Location {
             file,

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,10 +350,7 @@ mod test {
 
     fn pp<S: Into<Span>>(span: S, source: &str) -> String {
         let mut file_db = Files::new();
-        let source = rcc::Source {
-            code: String::from(source).into(),
-            path: std::path::PathBuf::new(),
-        };
+        let source = String::from(source).into());
         let file = file_db.add("<test-suite>", source);
         let location = Location {
             file,

--- a/tests/hfuzz.sh
+++ b/tests/hfuzz.sh
@@ -2,5 +2,10 @@
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT/fuzz"
 
+# honggfuzz can't handle absolute paths
+case "$CARGO_TARGET_DIR" in
+	/*) unset CARGO_TARGET_DIR ;;
+esac
+
 cargo install honggfuzz
 cargo hfuzz run hfuzz

--- a/tests/stack-overflow.rs
+++ b/tests/stack-overflow.rs
@@ -34,7 +34,11 @@ fn run_all() -> Result<(), io::Error> {
 
 fn run_one(path: &path::Path) -> Result<(), io::Error> {
     println!("testing {}", path.display());
-    let status = Command::new("target/debug/rcc").arg(path).status().unwrap();
+    let target = std::env::var("CARGO_TARGET_DIR").unwrap_or("target".into());
+    let status = Command::new(format!("{}/debug/rcc", target))
+        .arg(path)
+        .status()
+        .unwrap();
     assert_eq!(status.code(), Some(102));
     Ok(())
 }


### PR DESCRIPTION
This was already legal (and crashed the preprocessor) before, this just makes it easier and removes the crash.