### PR TITLE
Fix crash on comment at end of line

### DIFF
--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1465,5 +1465,13 @@ int main() {}
         )
         .collect();
         assert_eq!(tokens, cpp("int main() {}").collect::<Vec<_>>());
+        assert_same(
+            "
+#if 1 /**//**/
+int main(){}
+#endif
+",
+            "int main() {}",
+        );
     }
 }

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -223,7 +223,11 @@ fn test_comments() {
         3
     );
     let bad_comment = lex("/* unterminated comments are an error ");
-    assert!(bad_comment.is_some() && bad_comment.unwrap().is_err());
+    assert!(
+        bad_comment.is_some() && bad_comment.as_ref().unwrap().is_err(),
+        "expected unterminated comment err, got {:?}",
+        bad_comment
+    );
     // check for stack overflow
     assert_eq!(lex(&"//".repeat(10_000)), None);
     assert_eq!(lex(&"/* */".repeat(10_000)), None);


### PR DESCRIPTION
I assumed that consume_whitespace() will consume tokens
up until right before the next token, but it doesn't,
there could be comments in the middle.

Closes #292 