### PR TITLE
Add back support for 1.37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ jobs:
               bash <(curl -s https://codecov.io/bash) &&
               echo "Uploaded code coverage"
 
+        - rust: 1.37.0
+          # make sure we're backwards compatible
+          script: cargo check
+
         - rust: beta
           # sometimes rustfmt changes its mind about formatting between releases
           script: cargo test

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -185,10 +185,13 @@ impl<'a> PreProcessor<'a> {
         match self.next_replacement_token() {
             None => Ok(None),
             Some(Err(err)) => Err(err),
-            Some(Ok(matching)) if matching.data == token => Ok(Some(matching.location)),
-            Some(Ok(other)) => {
-                self.pending.push_front(other);
-                Ok(None)
+            Some(Ok(next)) => {
+                if next.data == token {
+                    Ok(Some(next.location))
+                } else {
+                    self.pending.push_front(next);
+                    Ok(None)
+                }
             }
         }
     }
@@ -368,8 +371,12 @@ impl<'a> PreProcessor<'a> {
                         Err(Locatable::new(CppError::InvalidDirective.into(), location))
                     }
                 }
-                Ok(other) if self.line() == line => {
-                    Err(other.map(|tok| CppError::UnexpectedToken("directive", tok).into()))
+                Ok(other) => {
+                    if self.line() == line {
+                        Err(other.map(|tok| CppError::UnexpectedToken("directive", tok).into()))
+                    } else {
+                        Ok(other.into())
+                    }
                 }
                 other => other.map(Locatable::from),
             }


### PR DESCRIPTION
It turns out this was lost by accident because I used bind-by-move :(