### PR TITLE
Allow setting macros at the command line

### DIFF
--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -429,7 +429,14 @@ pub(crate) mod test {
     pub(crate) fn cpp_no_newline(s: &str) -> PreProcessor {
         let mut files: Files = Default::default();
         let id = files.add("<test suite>", String::new().into());
-        PreProcessor::new(id, s, false, vec![], Box::leak(Box::new(files)))
+        PreProcessor::new(
+            id,
+            s,
+            false,
+            vec![],
+            Default::default(),
+            Box::leak(Box::new(files)),
+        )
     }
 
     #[test]

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -429,14 +429,7 @@ pub(crate) mod test {
     pub(crate) fn cpp_no_newline(s: &str) -> PreProcessor {
         let mut files: Files = Default::default();
         let id = files.add("<test suite>", String::new().into());
-        PreProcessor::new(
-            id,
-            s,
-            false,
-            vec![],
-            Default::default(),
-            Box::leak(Box::new(files)),
-        )
+        PreProcessorBuilder::new(s, id, Box::leak(Box::new(files))).build()
     }
 
     #[test]

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -69,6 +69,10 @@ impl<'a> PreProcessorBuilder<'a> {
         self.search_path.push(path.into());
         self
     }
+    pub fn definition<D: Into<Definition>>(mut self, name: InternedStr, def: D) -> Self {
+        self.definitions.insert(name, def.into());
+        self
+    }
     pub fn build(self) -> PreProcessor<'a> {
         PreProcessor::new(
             self.file,

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -172,7 +172,7 @@ impl From<Vec<Token>> for Definition {
 }
 
 impl TryFrom<&str> for Definition {
-    type Error = Error;
+    type Error = error::LexError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let value = Rc::from(format!("{}\n", value));
         let mut files = codespan::Files::new();
@@ -185,7 +185,6 @@ impl TryFrom<&str> for Definition {
             })
             .collect::<Result<_, _>>()
             .map(Definition::Object)
-            .map_err(Into::into)
     }
 }
 

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -10,7 +10,7 @@ mod cpp;
 #[cfg(test)]
 mod tests;
 // https://github.com/rust-lang/rust/issues/64762
-//#[allow(unreachable_pub)]
+#[allow(unreachable_pub)]
 pub use cpp::{Definition, PreProcessor, PreProcessorBuilder};
 
 type LexResult<T = Token> = Result<T, Locatable<LexError>>;

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -7,9 +7,11 @@ use super::data::{error::LexError, lex::*, *};
 use super::intern::InternedStr;
 
 mod cpp;
-pub use cpp::{PreProcessor, PreProcessorBuilder};
 #[cfg(test)]
 mod tests;
+// https://github.com/rust-lang/rust/issues/64762
+//#[allow(unreachable_pub)]
+pub use cpp::{Definition, PreProcessor, PreProcessorBuilder};
 
 type LexResult<T = Token> = Result<T, Locatable<LexError>>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ mod jit {
     impl TryFrom<Rc<str>> for JIT {
         type Error = Error;
         fn try_from(program: Rc<str>) -> Result<JIT, Self::Error> {
-            JIT::from_string(program, &Opt::default()).0
+            JIT::from_string(program, Opt::default()).0
         }
     }
 
@@ -348,7 +348,7 @@ mod jit {
         /// Compile string and return JITed code.
         pub fn from_string<R: Into<Rc<str>>>(
             program: R,
-            opt: &Opt,
+            opt: Opt,
         ) -> (Result<Self, Error>, VecDeque<CompileWarning>) {
             let program = program.into();
             let module = initialize_jit_module();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub use analyze::Analyzer;
 pub use data::*;
 // https://github.com/rust-lang/rust/issues/64762
 #[allow(unreachable_pub)]
-pub use lex::{Lexer, Definition, PreProcessor, PreProcessorBuilder};
+pub use lex::{Definition, Lexer, PreProcessor, PreProcessorBuilder};
 pub use parse::Parser;
 
 #[macro_use]
@@ -444,7 +444,7 @@ mod tests {
         let options = Opt::default();
         let mut files: Files = Default::default();
         let id = files.add("<test suite>", src.into());
-        let res = super::check_semantics(src, &options, id, &mut files).0;
+        let res = super::check_semantics(src, options, id, &mut files).0;
         match res {
             Ok(decls) => Ok(decls.into_iter().map(|l| l.data).collect()),
             Err(errs) => Err(Error::Source(errs)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub type WarningResult<T> = (Result<T, VecDeque<CompileError>>, VecDeque<Compile
 pub use analyze::Analyzer;
 pub use data::*;
 // https://github.com/rust-lang/rust/issues/64762
+#[allow(unreachable_pub)]
 pub use lex::{Lexer, Definition, PreProcessor, PreProcessorBuilder};
 pub use parse::Parser;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ struct BinOpt {
     filename: PathBuf,
 }
 
-// TODO: when std::process::termination is stable, make err_exit an impl for CompilerError
+// TODO: when std::process::termination is stable, make err_exit an impl for CompileError
 // TODO: then we can move this into `main` and have main return `Result<(), Error>`
 fn real_main(
     buf: Rc<str>,
@@ -268,11 +268,15 @@ fn parse_args() -> Result<(BinOpt, PathBuf), pico_args::Error> {
         use std::convert::TryInto;
 
         let mut iter = arg.splitn(2, '=');
-        let key = iter.next().unwrap();
+        let key = iter
+            .next()
+            .expect("apparently I don't understand pico_args");
         let val = iter.next().unwrap_or("1");
         let def = val
             .try_into()
-            .expect("error handling for defines not implemented");
+            .map_err(|err: rcc::data::Error| pico_args::Error::ArgumentParsingFailed {
+                cause: err.to_string(),
+            })?;
         definitions.insert(key.into(), def);
     }
     Ok((

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn real_main(
             aot_main(&buf, opt, file_id, file_db, output)
         } else {
             let module = rcc::initialize_jit_module();
-            let (result, warnings) = compile(module, &buf, &opt, file_id, file_db);
+            let (result, warnings) = compile(module, &buf, opt, file_id, file_db);
             handle_warnings(warnings, file_db);
             let mut rccjit = rcc::JIT::from(result?);
             if let Some(exit_code) = unsafe { rccjit.run_main() } {

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,11 +272,11 @@ fn parse_args() -> Result<(BinOpt, PathBuf), pico_args::Error> {
             .next()
             .expect("apparently I don't understand pico_args");
         let val = iter.next().unwrap_or("1");
-        let def = val
-            .try_into()
-            .map_err(|err: rcc::data::Error| pico_args::Error::ArgumentParsingFailed {
+        let def = val.try_into().map_err(|err: rcc::data::Error| {
+            pico_args::Error::ArgumentParsingFailed {
                 cause: err.to_string(),
-            })?;
+            }
+        })?;
         definitions.insert(key.into(), def);
     }
     Ok((

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,7 @@ fn parse_args() -> Result<(BinOpt, PathBuf), pico_args::Error> {
             .next()
             .expect("apparently I don't understand pico_args");
         let val = iter.next().unwrap_or("1");
-        let def = val.try_into().map_err(|err: rcc::data::Error| {
+        let def = val.try_into().map_err(|err: rcc::data::error::LexError| {
             pico_args::Error::ArgumentParsingFailed {
                 cause: err.to_string(),
             }

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -7,7 +7,7 @@ fn jit_readme() -> Result<(), Box<dyn std::error::Error>> {
     let _ = env_logger::try_init();
     let path = "tests/runner-tests/readme.c";
     let readme = std::fs::read_to_string(path)?;
-    let (jit, _warnings) = JIT::from_string(readme, &Opt::default());
+    let (jit, _warnings) = JIT::from_string(readme, Opt::default());
     let code = unsafe { jit?.run_main() };
     assert_eq!(code, Some(6));
     Ok(())

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -50,7 +50,7 @@ pub fn compile(program: &str, path: PathBuf, no_link: bool) -> Result<tempfile::
     };
     let id = files.add("<test-suite>", source);
     let module = rcc::initialize_aot_module(program.to_owned());
-    let (result, _warnings) = rcc::compile(module, program, &opts, id, &mut files);
+    let (result, _warnings) = rcc::compile(module, program, opts, id, &mut files);
     let module = result?.finish();
     let output = tempfile::NamedTempFile::new()
         .expect("cannot create tempfile")


### PR DESCRIPTION
~~Waiting on #305~~ merged. ~~The error type for `impl TryFrom<&str> for Vec<Token>` should be changed to LexError when #306 is merged~~ done. ~~Needs to remove the `unwrap()` in main (```-D 'a=`'``` will cause a crash)~~ done.