### PR TITLE
Correctly calculate struct size from alignment

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -80,6 +80,7 @@ impl StructType {
             .and_then(|size_t| {
                 let align_minus_one = self.align()? - 1;
 
+                // Rounds up to the next multiple of `align`
                 Ok((size_t + align_minus_one) & !align_minus_one)
             })
     }
@@ -265,9 +266,12 @@ mod tests {
             _ => complex_type_for_size(size),
         }
     }
+
+    #[inline]
     fn complex_type_for_size(size: u16) -> Type {
         struct_for_types(vec![Type::Char(true); size as usize])
     }
+
     fn symbol_for_type(ctype: Type, id: InternedStr) -> Symbol {
         Symbol {
             id,

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -263,13 +263,8 @@ mod tests {
             SHORT_SIZE => Type::Short(true),
             INT_SIZE => Type::Int(true),
             LONG_SIZE => Type::Long(true),
-            _ => complex_type_for_size(size),
+            _ => struct_for_types(vec![Type::Char(true); size as usize]),
         }
-    }
-
-    #[inline]
-    fn complex_type_for_size(size: u16) -> Type {
-        struct_for_types(vec![Type::Char(true); size as usize])
     }
 
     fn symbol_for_type(ctype: Type, id: InternedStr) -> Symbol {

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -341,7 +341,7 @@ mod tests {
     }
     #[test]
     fn align_of_non_char_struct() {
-        let ty = struct_for_types(vec![Int(true), Int(true)]);
-        assert_eq!(ty.alignof(), Ok(4));
+        let ty = struct_for_types(vec![Pointer(Box::new(Int(true))), Int(true)]);
+        assert_eq!(ty.alignof(), Ok(8));
     }
 }

--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -339,4 +339,9 @@ mod tests {
         assert_offset(vec![Type::Int(true), Type::Char(true)], 1, 4);
         assert_eq!(char_struct.sizeof().unwrap(), 5);
     }
+    #[test]
+    fn align_of_non_char_struct() {
+        let ty = struct_for_types(vec![Int(true), Int(true)]);
+        assert_eq!(ty.alignof(), Ok(4));
+    }
 }

--- a/tests/runner-tests/expr/assign/struct_align.c
+++ b/tests/runner-tests/expr/assign/struct_align.c
@@ -1,5 +1,7 @@
-// succeeds
+// code: 1
 int main() {
 	struct S { int *y, z; } s, ss;
+	ss.z = 1;
 	s = ss;
+	return s.z;
 }

--- a/tests/runner-tests/expr/assign/struct_align.c
+++ b/tests/runner-tests/expr/assign/struct_align.c
@@ -1,0 +1,5 @@
+// succeeds
+int main() {
+	struct S { int *y, z; } s, ss;
+	s = ss;
+}


### PR DESCRIPTION
Fixes #278.

This change takes struct alignment when calculating the size, specifically that it should round up to the nearest multiple of alignment. It also changes the `complex_type_for_size` to use all `char`s instead of filling in with larger types which have a higher alignment requirement.