### PR TITLE
Replaced hexf with hexponent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-module = "0.59"
 cranelift-object = "0.59"
 cranelift-simplejit = { version = "0.59", optional = true }
 env_logger = { version = "0.7", default-features = false, optional = true }
-hexf-parse = "0.1"
+hexponent = "0.2"
 thiserror = ">=1.0.9"
 log = "0.4"
 target-lexicon = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-module = "0.59"
 cranelift-object = "0.59"
 cranelift-simplejit = { version = "0.59", optional = true }
 env_logger = { version = "0.7", default-features = false, optional = true }
-hexponent = "0.2"
+hexponent = "0.2.2"
 thiserror = ">=1.0.9"
 log = "0.4"
 target-lexicon = "0.10"

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -331,7 +331,7 @@ pub enum LexError {
     FloatUnderflow,
 
     #[error("{0}")]
-    InvalidHexFloat(hexponent::ParseError),
+    InvalidHexFloat(#[from] hexponent::ParseError),
 
     #[doc(hidden)]
     #[error("internal error: do not construct nonexhaustive variants")]

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -280,9 +280,6 @@ pub enum CppError {
 /// Lex errors are non-exhaustive and may have new variants added at any time
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum LexError {
-    #[error("{0}")]
-    Generic(String),
-
     #[error("unterminated /* comment")]
     UnterminatedComment,
 
@@ -332,6 +329,9 @@ pub enum LexError {
 
     #[error("underflow parsing floating literal")]
     FloatUnderflow,
+
+    #[error("{0}")]
+    InvalidHexFloat(hexponent::ParseError),
 
     #[doc(hidden)]
     #[error("internal error: do not construct nonexhaustive variants")]
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_compile_error_is_kind() {
-        let e = Error::Lex(LexError::Generic("".to_string()));
+        let e = Error::Lex(LexError::UnterminatedComment);
         assert!(e.is_lex_err());
         assert!(!e.is_semantic_err());
         assert!(!e.is_syntax_err());

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -352,8 +352,6 @@ impl Lexer {
         if hex {
             if self.match_next(b'p') || self.match_next(b'P') {
                 if !is_digit(self.peek()) {
-                    // I'm leaving this as a generic error because I will get
-                    // rid of it with hexponent.
                     return Err(LexError::ExponentMissingDigits);
                 }
                 buf.push('p');

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -354,9 +354,7 @@ impl Lexer {
                 if !is_digit(self.peek()) {
                     // I'm leaving this as a generic error because I will get
                     // rid of it with hexponent.
-                    return Err(LexError::Generic(
-                        "exponent for floating literal has no digits".to_string(),
-                    ));
+                    return Err(LexError::ExponentMissingDigits);
                 }
                 buf.push('p');
                 buf.push(self.next_char().unwrap() as char);
@@ -377,9 +375,8 @@ impl Lexer {
             self.next_char();
         }
         let float: f64 = if hex {
-            let float_literal: hexponent::FloatLiteral = buf
-                .parse()
-                .map_err(|err: hexponent::ParseError| LexError::Generic(err.to_string()))?;
+            let float_literal: hexponent::FloatLiteral =
+                buf.parse().map_err(LexError::InvalidHexFloat)?;
             float_literal.into()
         } else {
             buf.parse::<f64>()?

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -375,8 +375,7 @@ impl Lexer {
             self.next_char();
         }
         let float: f64 = if hex {
-            let float_literal: hexponent::FloatLiteral =
-                buf.parse().map_err(LexError::InvalidHexFloat)?;
+            let float_literal: hexponent::FloatLiteral = buf.parse()?;
             float_literal.into()
         } else {
             buf.parse()?

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -376,10 +376,11 @@ impl Lexer {
             buf.push(c);
             self.next_char();
         }
-        let float = if hex {
-            // Leaving as generic because it will be replaced shortly.
-            hexf_parse::parse_hexf64(&buf, false)
-                .map_err(|err| LexError::Generic(err.to_string()))?
+        let float: f64 = if hex {
+            let float_literal: hexponent::FloatLiteral = buf
+                .parse()
+                .map_err(|err: hexponent::ParseError| LexError::Generic(err.to_string()))?;
+            float_literal.into()
         } else {
             buf.parse::<f64>()?
         };

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -379,7 +379,7 @@ impl Lexer {
                 buf.parse().map_err(LexError::InvalidHexFloat)?;
             float_literal.into()
         } else {
-            buf.parse::<f64>()?
+            buf.parse()?
         };
         let should_be_zero = buf.bytes().all(|c| match c {
             b'.' | b'+' | b'-' | b'e' | b'p' | b'0' => true,


### PR DESCRIPTION
This first revision is a 1:1 replacement. Improvements can be made by using features that `hexponenet` has and `hexf` doesn't.