### PR TITLE
Fix overflow in lexer

### DIFF
--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -532,8 +532,8 @@ impl Lexer {
         loop {
             match self.peek() {
                 Some(c) if b'0' <= c && c <= b'9' => update(self, c - b'0'),
-                Some(c) if b'a' <= c && c <= b'z' => update(self, c - b'a' + 10),
-                Some(c) if b'A' <= c && c <= b'Z' => update(self, c - b'A' + 10),
+                Some(c) if b'a' <= c && c <= b'f' => update(self, c - b'a' + 10),
+                Some(c) if b'A' <= c && c <= b'F' => update(self, c - b'A' + 10),
                 _ => break,
             }
         }

--- a/src/lex/tests.rs
+++ b/src/lex/tests.rs
@@ -263,6 +263,7 @@ fn test_characters() {
         .unwrap()
         .unwrap_err()
         .is_lex_err());
+    assert!(lex(r"'\xffuuuuuuuuuuuuuuuX'").unwrap().unwrap_err().is_lex_err());
 }
 #[test]
 fn test_strings() {


### PR DESCRIPTION
Closes https://github.com/jyn514/rcc/issues/339.

Also catches an error for `'\xff00000000000000ff'`, which before was lexed the same as `'\xff'`.