### PR TITLE
Make the codegen part of rcc optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jobs:
 
           script:
             - tests/pre-commit.sh
+            - cargo test --all-features
+            - cargo test --no-default-features
           # upload coverage statistics to codecov.io
           env: RUSTFLAGS="-C link-dead-code"
           addons:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,18 @@ required-features = ["jit"]
 name = "jit"
 required-features = ["jit"]
 
+[[test]]
+name = "runner"
+required-features = ["cc"]
+
+[[test]]
+name = "varargs"
+required-features = ["cc"]
+
+[[test]]
+name = "headers"
+required-features = ["cc"]
+
 [profile.release]
 lto = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = ">=1.0.10"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
 pico-args = { version = "0.3", optional = true }
-string-interner = "0.7"
+string-interner = { version = "0.7", default-features = false }
 codespan = "0.8"
 color-backtrace = { version = "0.3", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,8 @@ cranelift = { version = "0.59", optional = true }
 cranelift-module = { version = "0.59", optional = true }
 cranelift-object = { version = "0.59", optional = true }
 cranelift-simplejit = { version = "0.59", optional = true }
-env_logger = { version = "0.7", default-features = false, optional = true }
 hexponent = "0.2.2"
 thiserror = ">=1.0.10"
-log = "0.4"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
 pico-args = { version = "0.3", optional = true }
@@ -31,6 +29,8 @@ codespan = "0.8"
 color-backtrace = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
+env_logger = { version = "0.7", default-features = false }
+log = "0.4"
 criterion = "0.3.1"
 walkdir = "2"
 proptest = "0.9"
@@ -39,7 +39,7 @@ proptest-derive = "0.1"
 [features]
 default = ["cc", "codegen"]
 # The `rcc` binary
-cc = ["ansi_term", "tempfile", "pico-args", "color-backtrace", "env_logger", "codegen"]
+cc = ["ansi_term", "tempfile", "pico-args", "color-backtrace", "codegen"]
 codegen = ["cranelift", "cranelift-module", "cranelift-object"]
 jit = ["codegen", "cranelift-simplejit"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ documentation = "https://docs.rs/rcc"
 [dependencies]
 lazy_static = "1"
 ansi_term = { version = "0.12", optional = true }
-cranelift = "0.59"
-cranelift-module = "0.59"
-cranelift-object = "0.59"
+cranelift = { version = "0.59", optional = true }
+cranelift-module = { version = "0.59", optional = true }
+cranelift-object = { version = "0.59", optional = true }
 cranelift-simplejit = { version = "0.59", optional = true }
 env_logger = { version = "0.7", default-features = false, optional = true }
 hexponent = "0.2.2"
@@ -37,14 +37,16 @@ proptest = "0.9"
 proptest-derive = "0.1"
 
 [features]
-default = ["bin"]
-bin = ["ansi_term", "tempfile", "pico-args", "color-backtrace", "env_logger"]
-jit = ["cranelift-simplejit"]
+default = ["cc", "codegen"]
+# The `rcc` binary
+cc = ["ansi_term", "tempfile", "pico-args", "color-backtrace", "env_logger", "codegen"]
+codegen = ["cranelift", "cranelift-module", "cranelift-object"]
+jit = ["codegen", "cranelift-simplejit"]
 
 [[bin]]
 name = "rcc"
 path = "src/main.rs"
-required-features = ["bin"]
+required-features = ["cc"]
 
 [[bench]]
 name = "examples"

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -151,6 +151,8 @@ pub enum SemanticError {
     #[error("unreachable statement")]
     UnreachableStatement,
 
+    // TODO: this error should happen way before codegen
+    #[cfg(feature = "codegen")]
     #[error("redeclaration of label {0}")]
     LabelRedeclaration(cranelift::prelude::Block),
 

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
 use codespan::{FileId, Span};
-use cranelift::codegen::ir::condcodes::{FloatCC, IntCC};
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 
@@ -234,34 +233,6 @@ impl Literal {
     }
 }
 
-impl ComparisonToken {
-    pub fn to_int_compare(self, signed: bool) -> IntCC {
-        use ComparisonToken::*;
-        match (self, signed) {
-            (Less, true) => IntCC::SignedLessThan,
-            (Less, false) => IntCC::UnsignedLessThan,
-            (LessEqual, true) => IntCC::SignedLessThanOrEqual,
-            (LessEqual, false) => IntCC::UnsignedLessThanOrEqual,
-            (Greater, true) => IntCC::SignedGreaterThan,
-            (Greater, false) => IntCC::UnsignedGreaterThan,
-            (GreaterEqual, true) => IntCC::SignedGreaterThanOrEqual,
-            (GreaterEqual, false) => IntCC::UnsignedGreaterThanOrEqual,
-            (EqualEqual, _) => IntCC::Equal,
-            (NotEqual, _) => IntCC::NotEqual,
-        }
-    }
-    pub fn to_float_compare(self) -> FloatCC {
-        use ComparisonToken::*;
-        match self {
-            Less => FloatCC::LessThan,
-            LessEqual => FloatCC::LessThanOrEqual,
-            Greater => FloatCC::GreaterThan,
-            GreaterEqual => FloatCC::GreaterThanOrEqual,
-            EqualEqual => FloatCC::Equal,
-            NotEqual => FloatCC::NotEqual,
-        }
-    }
-}
 impl AssignmentToken {
     pub fn without_assignment(self) -> Token {
         use AssignmentToken::*;

--- a/src/ir/expr.rs
+++ b/src/ir/expr.rs
@@ -1,7 +1,6 @@
 use cranelift::codegen::ir::{condcodes, types, MemFlags};
 use cranelift::prelude::{FunctionBuilder, InstBuilder, Type as IrType, Value as IrValue};
 use cranelift_module::Backend;
-use log::debug;
 
 use super::{Compiler, Id};
 use crate::data::prelude::*;
@@ -575,7 +574,6 @@ impl<B: Backend> Compiler<B> {
                 if arg.ctype.is_floating() {
                     float_variadic += 1;
                 }
-                debug!("adding variadic arg with type {}", arg.ctype);
                 ftype.params.push(Symbol {
                     ctype: arg.ctype.clone(),
                     id: Default::default(),
@@ -590,7 +588,6 @@ impl<B: Backend> Compiler<B> {
             .map(|arg| self.compile_expr(arg, builder).map(|val| val.ir_val))
             .collect::<CompileResult<_>>()?;
         if ftype.varargs {
-            debug!("adding number of float args");
             let float_ir = builder.ins().iconst(types::I8, float_variadic);
             compiled_args.push(float_ir);
         }

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -5,20 +5,71 @@ mod stmt;
 use std::collections::{HashMap, VecDeque};
 use std::convert::TryFrom;
 
-use crate::data::{prelude::*, types::FunctionType, Initializer, Scope, StorageClass};
+use crate::arch::{CHAR_BIT, PTR_SIZE, SIZE_T, TARGET};
+use crate::data::{
+    lex::ComparisonToken, prelude::*, types::FunctionType, Initializer, Scope, StorageClass,
+};
 use cranelift::codegen::{
     self,
     ir::{
+        condcodes::{FloatCC, IntCC},
         entities::StackSlot,
         function::Function,
         stackslot::{StackSlotData, StackSlotKind},
-        ExternalName, InstBuilder, MemFlags,
+        types::{self, Type as IrType},
+        AbiParam, ArgumentPurpose, ExternalName, InstBuilder, MemFlags, Signature,
     },
-    settings,
+    isa::{CallConv, TargetIsa},
+    settings::{self, Configurable, Flags},
 };
 use cranelift::frontend::Switch;
-use cranelift::prelude::{Block, FunctionBuilder, FunctionBuilderContext, Signature};
+use cranelift::prelude::{Block, FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{self, Backend, DataId, FuncId, Linkage, Module};
+use cranelift_object::{ObjectBackend, ObjectBuilder, ObjectTrapCollection};
+use lazy_static::lazy_static;
+
+// TODO: make this const when const_if_match is stabilized
+// TODO: see https://github.com/rust-lang/rust/issues/49146
+lazy_static! {
+    /// The calling convention for the current target.
+    pub(crate) static ref CALLING_CONVENTION: CallConv = CallConv::triple_default(&TARGET);
+}
+
+pub(crate) fn get_isa(jit: bool) -> Box<dyn TargetIsa + 'static> {
+    let mut flags_builder = cranelift::codegen::settings::builder();
+    // `simplejit` requires non-PIC code
+    if !jit {
+        // allow creating shared libraries
+        flags_builder
+            .enable("is_pic")
+            .expect("is_pic should be a valid option");
+    }
+    // use debug assertions
+    flags_builder
+        .enable("enable_verifier")
+        .expect("enable_verifier should be a valid option");
+    // minimal optimizations
+    flags_builder
+        .set("opt_level", "speed")
+        .expect("opt_level: speed should be a valid option");
+    // don't emit call to __cranelift_probestack
+    flags_builder
+        .set("enable_probestack", "false")
+        .expect("enable_probestack should be a valid option");
+    let flags = Flags::new(flags_builder);
+    cranelift::codegen::isa::lookup(TARGET)
+        .unwrap_or_else(|_| panic!("platform not supported: {}", TARGET))
+        .finish(flags)
+}
+
+pub fn initialize_aot_module(name: String) -> Module<ObjectBackend> {
+    Module::new(ObjectBuilder::new(
+        get_isa(false),
+        name,
+        ObjectTrapCollection::Disabled,
+        cranelift_module::default_libcall_names(),
+    ))
+}
 
 enum Id {
     Function(FuncId),
@@ -329,5 +380,110 @@ impl<B: Backend> Compiler<B> {
 impl FunctionType {
     fn has_params(&self) -> bool {
         !(self.params.len() == 1 && self.params[0].ctype == Type::Void)
+    }
+
+    /// Generate the IR function signature for `self`
+    pub fn signature(&self, isa: &dyn TargetIsa) -> Signature {
+        let mut params = if self.params.len() == 1 && self.params[0].ctype == Type::Void {
+            // no arguments
+            Vec::new()
+        } else {
+            self.params
+                .iter()
+                .map(|param| AbiParam::new(param.ctype.as_ir_type()))
+                .collect()
+        };
+        if self.varargs {
+            let al = isa
+                .register_info()
+                .parse_regunit("rax")
+                .expect("x86 should have an rax register");
+            params.push(AbiParam::special_reg(
+                types::I8,
+                ArgumentPurpose::Normal,
+                al,
+            ));
+        }
+        let return_type = if !self.should_return() {
+            vec![]
+        } else {
+            vec![AbiParam::new(self.return_type.as_ir_type())]
+        };
+        Signature {
+            call_conv: *CALLING_CONVENTION,
+            params,
+            returns: return_type,
+        }
+    }
+}
+
+impl ComparisonToken {
+    pub fn to_int_compare(self, signed: bool) -> IntCC {
+        use ComparisonToken::*;
+        match (self, signed) {
+            (Less, true) => IntCC::SignedLessThan,
+            (Less, false) => IntCC::UnsignedLessThan,
+            (LessEqual, true) => IntCC::SignedLessThanOrEqual,
+            (LessEqual, false) => IntCC::UnsignedLessThanOrEqual,
+            (Greater, true) => IntCC::SignedGreaterThan,
+            (Greater, false) => IntCC::UnsignedGreaterThan,
+            (GreaterEqual, true) => IntCC::SignedGreaterThanOrEqual,
+            (GreaterEqual, false) => IntCC::UnsignedGreaterThanOrEqual,
+            (EqualEqual, _) => IntCC::Equal,
+            (NotEqual, _) => IntCC::NotEqual,
+        }
+    }
+    pub fn to_float_compare(self) -> FloatCC {
+        use ComparisonToken::*;
+        match self {
+            Less => FloatCC::LessThan,
+            LessEqual => FloatCC::LessThanOrEqual,
+            Greater => FloatCC::GreaterThan,
+            GreaterEqual => FloatCC::GreaterThanOrEqual,
+            EqualEqual => FloatCC::Equal,
+            NotEqual => FloatCC::NotEqual,
+        }
+    }
+}
+
+use std::convert::TryInto;
+impl Type {
+    /// Return an IR integer type large enough to contain a pointer.
+    pub fn ptr_type() -> IrType {
+        IrType::int(CHAR_BIT * PTR_SIZE).expect("pointer size should be valid")
+    }
+    /// Return an IR type which can represent this C type
+    pub fn as_ir_type(&self) -> IrType {
+        use Type::*;
+
+        match self {
+            // Integers
+            Bool => types::B1,
+            Char(_) | Short(_) | Int(_) | Long(_) | Pointer(_) | Enum(_, _) => {
+                let int_size = SIZE_T::from(CHAR_BIT)
+                    * self
+                        .sizeof()
+                        .expect("integers should always have a valid size");
+                IrType::int(int_size.try_into().unwrap_or_else(|_| {
+                    panic!(
+                        "integers should never have a size larger than {}",
+                        i16::max_value()
+                    )
+                }))
+                .unwrap_or_else(|| panic!("unsupported size for IR: {}", int_size))
+            }
+
+            // Floats
+            // TODO: this is hard-coded for x64
+            Float => types::F32,
+            Double => types::F64,
+
+            // Aggregates
+            // arrays and functions decay to pointers
+            Function(_) | Array(_, _) => IrType::int(PTR_SIZE * CHAR_BIT)
+                .unwrap_or_else(|| panic!("unsupported size of IR: {}", PTR_SIZE)),
+            // void cannot be loaded or stored
+            _ => types::INVALID,
+        }
     }
 }

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -1113,8 +1113,6 @@ impl<'a> PreProcessor<'a> {
         local: bool,
         start: u32,
     ) -> Result<PathBuf, Locatable<Error>> {
-        log::debug!("in search path");
-
         if filename.is_empty() {
             return Err(CompileError::new(
                 CppError::EmptyInclude.into(),
@@ -1193,7 +1191,6 @@ impl<'a> PreProcessor<'a> {
     // Returns every byte between the current position and the next `byte`.
     // Consumes and does not return the final `byte`.
     fn bytes_until(&mut self, byte: u8) -> Vec<u8> {
-        log::debug!("in bytes_until");
         let mut bytes = Vec::new();
         loop {
             match self.lexer_mut().next_char() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,7 @@ pub fn preprocess(
 }
 
 /// Perform semantic analysis, including type checking and constant folding.
+#[allow(clippy::type_complexity)]
 pub fn check_semantics(
     buf: &str,
     opt: &Opt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,14 +393,15 @@ impl<T: Into<Rc<str>>> From<T> for Source {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn compile(src: &str) -> Result<Product, Error> {
+    fn compile(src: &str) -> Result<Vec<Declaration>, Error> {
         let options = Opt::default();
-        let module = initialize_aot_module("RccAOT".to_owned());
         let mut files: Files = Default::default();
         let id = files.add("<test suite>", src.into());
-        super::compile(module, src, &options, id, &mut files)
-            .0
-            .map(|x| x.finish())
+        let res = super::check_semantics(src, &options, id, &mut files).0;
+        match res {
+            Ok(decls) => Ok(decls.into_iter().map(|l| l.data).collect()),
+            Err(errs) => Err(Error::Source(errs)),
+        }
     }
     fn compile_err(src: &str) -> VecDeque<CompileError> {
         match compile(src).err().unwrap() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,6 @@ extern crate ansi_term;
 extern crate codespan;
 #[cfg(debug_assertions)]
 extern crate color_backtrace;
-extern crate env_logger;
-extern crate log;
 extern crate pico_args;
 extern crate rcc;
 
@@ -91,8 +89,6 @@ fn real_main(
     opt: &BinOpt,
     output: &Path,
 ) -> Result<(), Error> {
-    env_logger::init();
-
     let opt = if opt.preprocess_only {
         use std::io::{BufWriter, Write};
 


### PR DESCRIPTION
This knocks down the number of dependencies from 80+ to only ~15 without features. Most of the rest are from thiserror, which I could probably make optional as well.