### PR TITLE
Don't run header tests on unknown systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ jobs:
 
           script:
             - tests/pre-commit.sh
+            # this also tests the header files
             - cargo test --all-features
             - cargo test --no-default-features
           # upload coverage statistics to codecov.io

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ default = ["cc", "codegen"]
 cc = ["ansi_term", "tempfile", "pico-args", "color-backtrace", "codegen"]
 codegen = ["cranelift", "cranelift-module", "cranelift-object"]
 jit = ["codegen", "cranelift-simplejit"]
+# for internal use
+_test_headers = []
 
 [[bin]]
 name = "rcc"
@@ -67,7 +69,8 @@ required-features = ["cc"]
 
 [[test]]
 name = "headers"
-required-features = ["cc"]
+# MacOS breaks if you pass -undef to the system preprocessor
+required-features = ["cc", "_test_header"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This reduces friction when people first contribute to rcc, since the header tests will usually fail if I haven't tested on that system.

cc @hdamron17