### PR TITLE
Get rid of BitfieldType

### DIFF
--- a/src/arch/mod.rs
+++ b/src/arch/mod.rs
@@ -129,7 +129,6 @@ impl Type {
             }
             Union(struct_type) => struct_type.union_size(),
             Struct(struct_type) => struct_type.struct_size(),
-            Bitfield(_) => unimplemented!("sizeof(bitfield)"),
             // illegal operations
             Function(_) => Err("cannot take `sizeof` a function"),
             Void => Err("cannot take `sizeof` void"),
@@ -154,7 +153,6 @@ impl Type {
             // Not sure why, but who am I to argue
             // Anyway, Faerie panics if the alignment isn't a power of two so it's probably for the best
             Union(struct_type) | Struct(struct_type) => struct_type.align(),
-            Bitfield(_) => unimplemented!("alignof bitfield"),
             Function(_) => Err("cannot take `alignof` function"),
             Void => Err("cannot take `alignof` void"),
             VaList => Err("cannot take `alignof` va_list"),

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -155,8 +155,6 @@ pub enum Type {
     Struct(StructType),
     /// Enums should always have members, since tentative definitions are not allowed
     Enum(Option<InternedStr>, Vec<(InternedStr, i64)>),
-    /// This should probably be merged into Structs at some point
-    Bitfield(Vec<BitfieldType>),
     /// This is the type used for variadic arguments.
     VaList,
     /// A semantic error occured while parsing this type.
@@ -183,14 +181,6 @@ pub struct FunctionType {
     pub return_type: Box<Type>,
     pub params: Vec<Symbol>,
     pub varargs: bool,
-}
-
-#[allow(dead_code)]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BitfieldType {
-    pub offset: i32,
-    pub name: Option<InternedStr>,
-    pub ctype: Type,
 }
 
 impl Type {
@@ -326,7 +316,6 @@ fn print_pre(ctype: &Type, f: &mut Formatter) -> fmt::Result {
         Union(_) => write!(f, "<anonymous union>"),
         Struct(StructType::Named(ident, _)) => write!(f, "struct {}", ident),
         Struct(_) => write!(f, "<anonymous struct>"),
-        Bitfield(_) => unimplemented!("printing bitfield type"),
         VaList => write!(f, "va_list"),
         Error => write!(f, "<type error>"),
     }
@@ -423,7 +412,6 @@ pub(crate) mod tests {
                 //Type::Function(FunctionType),
                 //Type::Union(StructType),
                 //Type::Struct(StructType),
-                //Type::Bitfield(Vec<BitfieldType>),
             ]
         })
     }

--- a/src/ir/static_init.rs
+++ b/src/ir/static_init.rs
@@ -256,8 +256,6 @@ impl<B: Backend> Compiler<B> {
                     }
                     Ok(())
                 }
-                Type::Bitfield(_) => unimplemented!("bitfield initalizers"),
-
                 Type::Function(_) => unreachable!("function initializers"),
                 Type::Void => unreachable!("initializer for void type"),
                 _ => unreachable!("scalar types should have been handled"),


### PR DESCRIPTION
Whenever I implement bitfields, it will be as part of structs, not a separate type.