### PR TITLE
Get rid of .constexpr field

### DIFF
--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -82,12 +82,6 @@ pub struct Expr {
     /// ctype: holds the type of the expression
     pub ctype: Type,
 
-    /// constexpr: whether a value can be constant-folded at compile-time
-    ///
-    /// unrelated to the `const` keyword
-    /// NOTE: can sometimes be true at the same time as `lval` (e.g. for constant arrays)
-    pub constexpr: bool,
-
     /// lval: whether an expression can be assigned to
     ///
     /// for example, variables, array elements, and pointer dereferences are lvals,

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -1314,7 +1314,6 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
         if !expr.lval && self.scope.is_global() && ctype.is_pointer() {
             expr = Expr {
                 lval: false,
-                constexpr: false,
                 location: expr.location,
                 ctype: expr.ctype.clone(),
                 expr: ExprType::StaticRef(Box::new(expr)),


### PR DESCRIPTION
It's literally useless. This instead checks if the expression was successfully folded.