### PR TITLE
Update cranelift to 0.63

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
               bash <(curl -s https://codecov.io/bash) &&
               echo "Uploaded code coverage"
 
-        - rust: 1.37.0
+        - rust: 1.38.0
           # make sure we're backwards compatible
           script: cargo check
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ documentation = "https://docs.rs/rcc"
 [dependencies]
 lazy_static = "1"
 ansi_term = { version = "0.12", optional = true }
-cranelift = { version = "0.59", optional = true }
-cranelift-module = { version = "0.59", optional = true }
-cranelift-object = { version = "0.59", optional = true }
-cranelift-simplejit = { version = "0.59", optional = true }
+cranelift = { version = "0.62", optional = true }
+cranelift-module = { version = "0.62", optional = true }
+cranelift-object = { version = "0.62", optional = true }
+cranelift-simplejit = { version = "0.62", optional = true }
 hexponent = "0.2.2"
 thiserror = ">=1.0.10"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
+object = { version = "0.18", default-features = false }
 pico-args = { version = "0.3", optional = true }
 string-interner = { version = "0.7", default-features = false }
 codespan = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ hexponent = "0.2.2"
 thiserror = ">=1.0.10"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
-object = { version = "0.18", default-features = false }
 pico-args = { version = "0.3", optional = true }
 string-interner = { version = "0.7", default-features = false }
 codespan = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ documentation = "https://docs.rs/rcc"
 [dependencies]
 lazy_static = "1"
 ansi_term = { version = "0.12", optional = true }
-cranelift = { version = "0.62", optional = true }
-cranelift-module = { version = "0.62", optional = true }
-cranelift-object = { version = "0.62", optional = true }
-cranelift-simplejit = { version = "0.62", optional = true }
+cranelift = { version = "0.63", optional = true }
+cranelift-module = { version = "0.63", optional = true }
+cranelift-object = { version = "0.63", optional = true }
+cranelift-simplejit = { version = "0.63", optional = true }
 hexponent = "0.2.2"
 thiserror = ">=1.0.10"
 target-lexicon = "0.10"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rcc
 
 [![Build Status](https://travis-ci.org/jyn514/rcc.svg?branch=master)](https://travis-ci.org/jyn514/rcc)
-![Minimum supported Rustc](https://img.shields.io/badge/rustc-1.37+-green.svg)
+![Minimum supported Rustc](https://img.shields.io/badge/rustc-1.38+-green.svg)
 [Join us on Discord](https://discord.gg/BPER7PF)
 
 rcc: a Rust C compiler

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -25,7 +25,7 @@ use cranelift::codegen::{
 use cranelift::frontend::Switch;
 use cranelift::prelude::{Block, FunctionBuilder, FunctionBuilderContext};
 use cranelift_module::{self, Backend, DataId, FuncId, Linkage, Module};
-use cranelift_object::{ObjectBackend, ObjectBuilder, ObjectTrapCollection};
+use cranelift_object::{ObjectBackend, ObjectBuilder};
 use lazy_static::lazy_static;
 
 // TODO: make this const when const_if_match is stabilized
@@ -66,7 +66,6 @@ pub fn initialize_aot_module(name: String) -> Module<ObjectBackend> {
     Module::new(ObjectBuilder::new(
         get_isa(false),
         name,
-        ObjectTrapCollection::Disabled,
         cranelift_module::default_libcall_names(),
     ))
 }
@@ -362,7 +361,11 @@ impl<B: Backend> Compiler<B> {
         }
 
         let mut ctx = codegen::Context::for_function(func);
-        if let Err(err) = self.module.define_function(func_id, &mut ctx) {
+        let mut trap_sink = codegen::binemit::NullTrapSink {};
+        if let Err(err) = self
+            .module
+            .define_function(func_id, &mut ctx, &mut trap_sink)
+        {
             panic!(
                 "definition error: {}\nnote: while compiling {}",
                 err, ctx.func

--- a/src/ir/static_init.rs
+++ b/src/ir/static_init.rs
@@ -47,6 +47,7 @@ impl<B: Backend> Compiler<B> {
                 get_str!(metadata.id),
                 linkage,
                 !metadata.qualifiers.c_const,
+                false,
                 Some(align),
             )
             .map_err(|err| Locatable {
@@ -114,7 +115,10 @@ impl<B: Backend> Compiler<B> {
             Entry::Occupied(id) => return Ok(*id.get()),
             Entry::Vacant(empty) => {
                 let name = format!("str.{}", len);
-                let id = match self.module.declare_data(&name, Linkage::Local, false, None) {
+                let id = match self
+                    .module
+                    .declare_data(&name, Linkage::Local, false, false, None)
+                {
                     Ok(id) => id,
                     Err(err) => {
                         semantic_err!(format!("error declaring static string: {}", err), location)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ mod parse;
 pub enum Error {
     #[error("{}", .0.iter().map(|err| err.data.to_string()).collect::<Vec<_>>().join("\n"))]
     Source(VecDeque<CompileError>),
+    #[cfg(feature = "codegen")]
     #[error("linking error: {0}")]
     Platform(object::write::Error),
     #[error("io error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@ mod parse;
 pub enum Error {
     #[error("{}", .0.iter().map(|err| err.data.to_string()).collect::<Vec<_>>().join("\n"))]
     Source(VecDeque<CompileError>),
-    #[error("platform-specific error: {0}")]
-    Platform(String),
+    #[error("linking error: {0}")]
+    Platform(object::write::Error),
     #[error("io error: {0}")]
     IO(#[from] io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub enum Error {
     Source(VecDeque<CompileError>),
     #[cfg(feature = "codegen")]
     #[error("linking error: {0}")]
-    Platform(object::write::Error),
+    Platform(cranelift_object::object::write::Error),
     #[error("io error: {0}")]
     IO(#[from] io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::cognitive_complexity)]
-// mem::take was stabilized in 1.40, but we support back to 1.37
+// mem::take was stabilized in 1.40, but we support back to 1.38
 #![allow(clippy::mem_replace_with_default)]
 #![warn(absolute_paths_not_starting_with_crate)]
 #![warn(explicit_outlives_requirements)]


### PR DESCRIPTION
~~I'm not super happy with this, I had to add a new dependency on `object` that's not linked to `cranelift_object`, so it will break when cranelift_object updates.~~ Resolved in 0.63