### PR TITLE
Remove MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ jobs:
               bash <(curl -s https://codecov.io/bash) &&
               echo "Uploaded code coverage"
 
-        - rust: 1.39.0
-          # make sure we're backwards compatible
-          script: cargo check
-
         - rust: beta
           script: cargo check
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
               bash <(curl -s https://codecov.io/bash) &&
               echo "Uploaded code coverage"
 
-        - rust: 1.38.0
+        - rust: 1.39.0
           # make sure we're backwards compatible
           script: cargo check
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rcc
 
 [![Build Status](https://travis-ci.org/jyn514/rcc.svg?branch=master)](https://travis-ci.org/jyn514/rcc)
-![Minimum supported Rustc](https://img.shields.io/badge/rustc-1.38+-green.svg)
+![Minimum supported Rustc](https://img.shields.io/badge/rustc-1.39+-green.svg)
 [Join us on Discord](https://discord.gg/BPER7PF)
 
 rcc: a Rust C compiler

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # rcc
 
 [![Build Status](https://travis-ci.org/jyn514/rcc.svg?branch=master)](https://travis-ci.org/jyn514/rcc)
-![Minimum supported Rustc](https://img.shields.io/badge/rustc-1.39+-green.svg)
 [Join us on Discord](https://discord.gg/BPER7PF)
 
 rcc: a Rust C compiler

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -108,6 +108,7 @@ pub enum Error {
 
 /// Semantic errors are non-exhaustive and may have new variants added at any time
 #[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
 pub enum SemanticError {
     #[error("{0}")]
     Generic(String),
@@ -177,14 +178,11 @@ pub enum SemanticError {
 
     #[error("initializers cannot be empty")]
     EmptyInitializer,
-
-    #[doc(hidden)]
-    #[error("internal error: do not construct nonexhaustive variants")]
-    __Nonexhaustive,
 }
 
 /// Syntax errors are non-exhaustive and may have new variants added at any time
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SyntaxError {
     #[error("{0}")]
     Generic(String),
@@ -194,14 +192,11 @@ pub enum SyntaxError {
 
     #[error("expected statement, got {0}")]
     NotAStatement(super::Keyword),
-
-    #[doc(hidden)]
-    #[error("internal error: do not construct nonexhaustive variants")]
-    __Nonexhaustive,
 }
 
 /// Preprocessing errors are non-exhaustive and may have new variants added at any time
 #[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
 pub enum CppError {
     /// A user-defined error (`#error`) was present.
     /// The `Vec<Token>` contains the tokens which followed the error.
@@ -273,14 +268,11 @@ pub enum CppError {
     /// b) an `#else` has already been seen.
     #[error("{}", if *early { "#elif without #if" } else { "#elif after #else " })]
     UnexpectedElif { early: bool },
-
-    #[doc(hidden)]
-    #[error("internal error: do not construct nonexhaustive variants")]
-    __Nonexhaustive,
 }
 
 /// Lex errors are non-exhaustive and may have new variants added at any time
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum LexError {
     #[error("unterminated /* comment")]
     UnterminatedComment,
@@ -334,13 +326,10 @@ pub enum LexError {
 
     #[error("{0}")]
     InvalidHexFloat(#[from] hexponent::ParseError),
-
-    #[doc(hidden)]
-    #[error("internal error: do not construct nonexhaustive variants")]
-    __Nonexhaustive,
 }
 
 #[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
 /// errors are non-exhaustive and may have new variants added at any time
 pub enum Warning {
     // for compatibility
@@ -358,10 +347,6 @@ pub enum Warning {
 
     #[error("variadic macros are not yet supported")]
     IgnoredVariadic,
-
-    #[doc(hidden)]
-    #[error("internal error: do not construct nonexhaustive variants")]
-    __Nonexhaustive,
 }
 
 impl<T: Into<String>> From<T> for Warning {

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -393,7 +393,7 @@ impl<'a> PreProcessor<'a> {
     /// These warnings are consumed and will not be returned if you call
     /// `warnings()` again.
     pub fn warnings(&mut self) -> VecDeque<CompileWarning> {
-        std::mem::replace(&mut self.error_handler.warnings, Default::default())
+        std::mem::take(&mut self.error_handler.warnings)
     }
 
     /* internal functions */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::cognitive_complexity)]
-// mem::take was stabilized in 1.40, but we support back to 1.38
-#![allow(clippy::mem_replace_with_default)]
 #![warn(absolute_paths_not_starting_with_crate)]
 #![warn(explicit_outlives_requirements)]
 #![warn(unreachable_pub)]

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -250,7 +250,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
     }
     fn next_token(&mut self) -> Option<Locatable<Token>> {
         if self.current.is_some() {
-            let tmp = mem::replace(&mut self.next, None);
+            let tmp = mem::take(&mut self.next);
             mem::replace(&mut self.current, tmp)
         } else {
             self.__impl_next_token()
@@ -365,7 +365,7 @@ impl<I: Iterator<Item = Lexeme>> Parser<I> {
     /// These warnings are consumed and will not be returned if you call
     /// `warnings()` again.
     pub fn warnings(&mut self) -> VecDeque<CompileWarning> {
-        std::mem::replace(&mut self.error_handler.warnings, Default::default())
+        std::mem::take(&mut self.error_handler.warnings)
     }
 }
 


### PR DESCRIPTION
Fixes failing master. Required because regalloc-rs doesn't compile with anything less than 1.40 and a MSRV doesn't make sense if Cranelift doesn't have one.