### PR TITLE
Remove unnecessary clone in recursion guard

### DIFF
--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -113,8 +113,9 @@ impl<I: Lexer> Analyzer<I> {
     fn warn(&mut self, w: Warning, l: Location) {
         self.error_handler.warn(w, l);
     }
-    fn recursion_check(&self) -> RecursionGuard {
-        self.recursion_guard.recursion_check(&self.error_handler)
+    fn recursion_check(&mut self) -> RecursionGuard {
+        self.recursion_guard
+            .recursion_check(&mut self.error_handler)
     }
     /// 6.9 External Definitions
     ///

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -133,8 +133,9 @@ impl<I: Lexer> Iterator for Parser<I> {
 }
 
 impl<I: Lexer> Parser<I> {
-    fn recursion_check(&self) -> RecursionGuard {
-        self.recursion_guard.recursion_check(&self.error_handler)
+    fn recursion_check(&mut self) -> RecursionGuard {
+        self.recursion_guard
+            .recursion_check(&mut self.error_handler)
     }
     // don't use this, use next_token instead
     fn __impl_next_token(&mut self) -> Option<Locatable<Token>> {


### PR DESCRIPTION
This also fixes a stack overflow for nightmare expressions.

cc @Byter09 