### PR TITLE
Make color-backtrace optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ proptest-derive = "0.1"
 [features]
 default = ["cc", "codegen"]
 # The `rcc` binary
-cc = ["ansi_term", "git-testament", "tempfile", "pico-args", "color-backtrace", "codegen", "atty"]
+cc = ["ansi_term", "git-testament", "tempfile", "pico-args", "codegen", "atty"]
 codegen = ["cranelift", "cranelift-module", "cranelift-object"]
 jit = ["codegen", "cranelift-simplejit"]
 # for internal use

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ proptest = "0.9"
 proptest-derive = "0.1"
 
 [features]
-default = ["cc", "codegen"]
+default = ["cc", "codegen", "color-backtrace"]
 # The `rcc` binary
 cc = ["ansi_term", "git-testament", "tempfile", "pico-args", "codegen", "atty"]
 codegen = ["cranelift", "cranelift-module", "cranelift-object"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@ use cranelift_module::{Backend, Module};
 #[cfg(feature = "codegen")]
 pub use ir::initialize_aot_module;
 
+#[cfg(all(feature = "color-backtrace", not(feature = "cc")))]
+compile_error!("The color-backtrace feature does nothing unless used by the `rcc` binary.");
+
 /// The `Source` type for `codespan::Files`.
 ///
 /// Used to store extra metadata about the file, like the absolute filename.

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,6 @@ use std::process;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[cfg(debug_assertions)]
-use color_backtrace::termcolor;
-
 use ansi_term::{ANSIString, Colour};
 use codespan::FileId;
 use git_testament::git_testament_macros;


### PR DESCRIPTION
Now it is no longer compiled when you pass `--no-default-features`.