### PR TITLE
Add --debug-hir flag and clean up debug options

### DIFF
--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -355,7 +355,7 @@ impl<B: Backend> Compiler<B> {
         let flags = settings::Flags::new(settings::builder());
 
         if self.debug {
-            println!("{}", func);
+            println!("ir: {}", func);
         }
 
         if let Err(err) = codegen::verify_function(&func, &flags) {

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -918,7 +918,7 @@ impl<'a> PreProcessor<'a> {
         // TODO: catch expressions that aren't allowed
         // (see https://github.com/jyn514/rcc/issues/5#issuecomment-575339427)
         // TODO: can semantic errors happen here? should we check?
-        Ok(Analyzer::new(parser).parse_expr(expr))
+        Ok(Analyzer::new(parser, false).parse_expr(expr))
     }
     /// We saw an `#if`, `#ifdef`, or `#ifndef` token at the start of the line
     /// and want to either take the branch or ignore the tokens within the directive.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,16 @@ pub struct Opt {
     /// If set, print all tokens found by the lexer in addition to compiling.
     pub debug_lex: bool,
 
-    /// If set, print the parsed abstract syntax tree in addition to compiling
+    /// If set, print the parsed abstract syntax tree (AST) in addition to compiling
+    ///
+    /// The AST does no type checking or validation, it only parses.
     pub debug_ast: bool,
+
+    /// If set, print the high intermediate representation (HIR) in addition to compiling
+    ///
+    /// This does type checking and validation and also desugars various expressions.
+    /// For static initialization, it will also perform constant folding.
+    pub debug_hir: bool,
 
     /// If set, print the intermediate representation of the program in addition to compiling
     pub debug_asm: bool,
@@ -235,7 +243,7 @@ pub fn check_semantics(
     };
 
     let mut hir = vec![];
-    let mut parser = Analyzer::new(Parser::new(first, &mut cpp, opt.debug_ast));
+    let mut parser = Analyzer::new(Parser::new(first, &mut cpp, opt.debug_ast), opt.debug_hir);
     for res in &mut parser {
         match res {
             Ok(decl) => hir.push(decl),

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,11 +40,12 @@ const HELP: &str = concat!(
     "usage: ", env!("CARGO_PKG_NAME"), " [FLAGS] [OPTIONS] [<file>]
 
 FLAGS:
-        --debug-asm        If set, print the intermediate representation of the program in addition to compiling.
-        --debug-ast        If set, print the parsed abstract syntax tree in addition to compiling.
-        --debug-lex        If set, print all tokens found by the lexer in addition to compiling.
+        --debug-ast        If set, print the parsed abstract syntax tree (AST) in addition to compiling.
+                            The AST does no type checking or validation, it only parses.
         --debug-hir        If set, print the high intermediate representation (HIR) in addition to compiling.
                             This does type checking and validation and also desugars various expressions.
+        --debug-ir         If set, print the intermediate representation (IR) of the program in addition to compiling.
+        --debug-lex        If set, print all tokens found by the lexer in addition to compiling.
         --jit              If set, will use JIT compilation for C code and instantly run compiled code (No files produced).
                             NOTE: this option only works if rcc was compiled with the `jit` feature.
     -h, --help             Prints help information
@@ -71,7 +72,7 @@ ARGS:
 );
 
 const USAGE: &str = "\
-usage: rcc [--help | -h] [--version | -V] [--debug-asm] [--debug-ast] [--debug-lex]
+usage: rcc [--help | -h] [--version | -V] [--debug-ir] [--debug-ast] [--debug-lex]
            [--debug-hir] [--jit] [--no-link | -c] [--preprocess-only | -E]
            [-I <dir>] [-D <id[=val]>] [<file>]";
 
@@ -348,7 +349,7 @@ fn parse_args() -> Result<(BinOpt, PathBuf), pico_args::Error> {
             preprocess_only: input.contains(["-E", "--preprocess-only"]),
             opt: Opt {
                 debug_lex: input.contains("--debug-lex"),
-                debug_asm: input.contains("--debug-asm"),
+                debug_asm: input.contains("--debug-ir"),
                 debug_ast: input.contains("--debug-ast"),
                 debug_hir: input.contains("--debug-hir"),
                 no_link: input.contains(["-c", "--no-link"]),

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -125,7 +125,7 @@ impl<I: Lexer> Iterator for Parser<I> {
             });
         if self.debug {
             if let Some(Ok(decl)) = &next {
-                println!("{}", decl.data);
+                println!("ast: {}", decl.data);
             }
         }
         next


### PR DESCRIPTION
- Rename `--debug-asm` to `--debug-ir`
- Print the kind of the item before printing it (e.g. "hir: ...")
- Add periods after help options
- Give a shorter usage message for `-h` than for `--help`
- Add missing `-E` option for `USAGE`
- Removed `-a` alias for `--debug-ast` since it's not super useful and is also unclear.

r? @pythondude325 