### PR TITLE
Use less recursion for function macro replacement

### DIFF
--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -783,6 +783,8 @@ impl<'a> PreProcessor<'a> {
                     .push_back(location.with(PendingToken::Replacement(token.clone())));
             }
         }
+        // NOTE: no errors could have occurred while parsing this function body
+        // since they would have returned before getting here.
         let first = self.pending.pop_front()?;
         self.handle_token(first.data, first.location)
     }


### PR DESCRIPTION
Partially addresses https://github.com/jyn514/rcc/issues/399 - that exact example no longer overflows, but it will still crash if you bump up the nesting a bit more.