### PR TITLE
Require proptest >= 0.9.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cranelift-module = { version = "0.63", optional = true }
 cranelift-object = { version = "0.63", optional = true }
 cranelift-simplejit = { version = "0.63", optional = true }
 hexponent = "0.3"
-thiserror = ">=1.0.10"
+thiserror = "^1.0.10"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
 pico-args = { version = "0.3", optional = true }
@@ -43,7 +43,7 @@ env_logger = { version = "0.7", default-features = false }
 log = "0.4"
 criterion = "0.3"
 walkdir = "2"
-proptest = "0.9"
+proptest = "^0.9.6"
 proptest-derive = "0.1"
 
 [features]


### PR DESCRIPTION
@hdamron17 ran into some trouble with 0.9.5, so this requires a version greater than that.

See also https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html