### PR TITLE
Grammar docs in code blocks and linked to online grammar

### DIFF
--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -24,7 +24,6 @@ type LexResult<T = Token> = Result<T, Locatable<LexError>>;
 /// You may also find the `warn` and `error` functions in `utils.rs` to be useful.
 ///
 /// Lexer implements iterator, so you can loop over the tokens.
-/// ```
 #[derive(Debug)]
 pub struct Lexer {
     location: SingleLocation,

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -40,6 +40,7 @@ impl<I: Lexer> Parser<I> {
     /// | declaration_specifiers init_declarator_list ';'
     /// ;
     /// ```
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#external_declaration>
     pub fn external_declaration(&mut self) -> SyntaxResult<Locatable<ExternalDeclaration>> {
         let (specifiers, specifier_locations) = self.specifiers()?;
 
@@ -178,6 +179,7 @@ impl<I: Lexer> Parser<I> {
     /// | (struct | union) identifier
     /// ;
     /// ```
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#struct_or_union_specifier>
     fn struct_specifier(
         &mut self,
         is_struct: bool,
@@ -232,6 +234,7 @@ impl<I: Lexer> Parser<I> {
     /// | declarator ':' constant_expr
     /// ;
     /// ```
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#struct_declaration>
     fn struct_declaration_list(&mut self) -> SyntaxResult<Locatable<ast::StructDeclarationList>> {
         //use data::lex::LocationTrait;
         let (specifiers, mut spec_location) = self.specifiers()?;
@@ -299,6 +302,7 @@ impl<I: Lexer> Parser<I> {
     /// | IDENTIFIER '=' constant_expression
     /// ;
     /// ```
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#enum_specifier>
 
     // we've already seen an `enum` token,, `location` is where we saw it
     fn enum_specifier(
@@ -422,6 +426,7 @@ impl<I: Lexer> Parser<I> {
      *  | direct_declarator '(' ')'
      *  | direct_declarator '(' parameter_type_list ')'
      *  ;
+     * <http://www.quut.com/c/ANSI-C-grammar-y.html#direct_declarator>
      *
      * Additionally, we combine abstract_declarators, because most of the code is the same.
      * direct_abstract_declarator
@@ -435,11 +440,12 @@ impl<I: Lexer> Parser<I> {
      *  | direct_abstract_declarator '(' ')'
      *  | direct_abstract_declarator '(' parameter_type_list ')'
      *  ;
+     * <http://www.quut.com/c/ANSI-C-grammar-y.html#direct_abstract_declarator>
      *
      * Because we can't handle left-recursion, we rewrite it as follows:
      * direct_abstract_declarator
-     *   | identifier postfix_type*
      *   : '(' abstract_declarator ')' postfix_type*
+     *   | identifier postfix_type*
      *   | postfix_type*  /* only for abstract_declarators */
      *   ;
      *
@@ -597,6 +603,7 @@ impl<I: Lexer> Parser<I> {
      *      | declaration_specifiers abstract_declarator
      *      ;
      *
+     * <http://www.quut.com/c/ANSI-C-grammar-y.html#parameter_type_list>
      */
     fn parameter_type_list(&mut self) -> SyntaxResult<Locatable<InternalDeclaratorType>> {
         let left_paren = self

--- a/src/parse/decl.rs
+++ b/src/parse/decl.rs
@@ -29,6 +29,7 @@ struct InternalDeclarator {
 }
 
 impl<I: Lexer> Parser<I> {
+    /// ```yacc
     /// external_declaration
     /// : function_definition
     /// | declaration
@@ -38,6 +39,7 @@ impl<I: Lexer> Parser<I> {
     /// : declaration_specifiers ';'
     /// | declaration_specifiers init_declarator_list ';'
     /// ;
+    /// ```
     pub fn external_declaration(&mut self) -> SyntaxResult<Locatable<ExternalDeclaration>> {
         let (specifiers, specifier_locations) = self.specifiers()?;
 
@@ -169,11 +171,13 @@ impl<I: Lexer> Parser<I> {
         }
         Ok((specifiers, all_locs))
     }
+    /// ```yacc
     /// struct_or_union_specifier
     /// : (struct | union) '{' struct_declaration + '}'
     /// | (struct | union) identifier '{' struct_declaration + '}'
     /// | (struct | union) identifier
     /// ;
+    /// ```
     fn struct_specifier(
         &mut self,
         is_struct: bool,
@@ -217,6 +221,7 @@ impl<I: Lexer> Parser<I> {
         Ok(Locatable::new(spec, start))
     }
 
+    /// ```yacc
     /// struct_declaration: (type_specifier | type_qualifier)+ struct_declarator_list ';'
     ///
     /// struct_declarator_list: struct_declarator (',' struct_declarator)* ;
@@ -226,6 +231,7 @@ impl<I: Lexer> Parser<I> {
     /// | ':' constant_expr  // bitfield, not supported
     /// | declarator ':' constant_expr
     /// ;
+    /// ```
     fn struct_declaration_list(&mut self) -> SyntaxResult<Locatable<ast::StructDeclarationList>> {
         //use data::lex::LocationTrait;
         let (specifiers, mut spec_location) = self.specifiers()?;
@@ -272,15 +278,16 @@ impl<I: Lexer> Parser<I> {
             location.maybe_merge(spec_location),
         ))
     }
+    /// ```yacc
     /// enum_specifier
-    ///  : 'enum' '{' enumerator_list '}'
-    ///  | 'enum' identifier '{' enumerator_list '}'
+    /// : 'enum' '{' enumerator_list '}'
+    /// | 'enum' identifier '{' enumerator_list '}'
 
     // this is not valid for declaring an enum, but it's fine for an enum we've already seen
     // e.g. `enum E { A }; enum E e;`
 
-    ///  | 'enum' identifier
-    ///  ;
+    /// | 'enum' identifier
+    /// ;
     ///
     /// enumerator_list
     /// : enumerator
@@ -291,6 +298,7 @@ impl<I: Lexer> Parser<I> {
     /// : IDENTIFIER
     /// | IDENTIFIER '=' constant_expression
     /// ;
+    /// ```
 
     // we've already seen an `enum` token,, `location` is where we saw it
     fn enum_specifier(
@@ -441,6 +449,7 @@ impl<I: Lexer> Parser<I> {
      *   | '(' ')'
      *   | '(' parameter_type_list ')'
      *   ;
+     * ```
      *
      *   How do we tell abstract_declarator and parameter_type_list apart?
      *   parameter_type_list starts with declaration specifiers, abstract_declarator doesn't:

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -155,6 +155,7 @@ impl<I: Lexer> Parser<I> {
                 // : logical_or_expression
                 // | logical_or_expression '?' expression ':' conditional_expression
                 // ;
+                // <http://www.quut.com/c/ANSI-C-grammar-y.html#conditional_expression>
                 let inner = self.expr()?;
                 self.expect(Token::Colon)?;
                 let right_start = self.unary_expr()?;

--- a/src/parse/expr.rs
+++ b/src/parse/expr.rs
@@ -242,6 +242,7 @@ impl<I: Lexer> Parser<I> {
     }
     // postfix_expression: primary_expression postfix_op*
     // primary_expression: '(' expr ')' | 'sizeof' unary_expression | 'alignof' unary_expression | ID | LITERAL
+    // <http://www.quut.com/c/ANSI-C-grammar-y.html#postfix_expression>
     //
     // TODO: `sizeof` and `alignof` should be unary expressions, not primary expressions
     #[inline]

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -76,6 +76,7 @@ impl<I: Lexer> Parser<I> {
 
 impl<I: Lexer> Iterator for Parser<I> {
     type Item = CompileResult<Locatable<ExternalDeclaration>>;
+    /// ```yacc
     /// translation_unit
     /// : external_declaration
     /// | translation_unit external_declaration
@@ -90,6 +91,7 @@ impl<I: Lexer> Iterator for Parser<I> {
     /// : declarator compound_statement
     /// | declaration_specifiers declarator compound_statement
     /// ;
+    /// ```
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             // check for pending changes from the last declaration

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -92,6 +92,7 @@ impl<I: Lexer> Iterator for Parser<I> {
     /// | declaration_specifiers declarator compound_statement
     /// ;
     /// ```
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#translation_unit>
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             // check for pending changes from the last declaration

--- a/src/parse/stmt.rs
+++ b/src/parse/stmt.rs
@@ -68,10 +68,6 @@ impl<I: Lexer> Parser<I> {
     /// | DEFAULT ':' statement
     /// ;
     /// ```
-    ///
-    /// Result: whether there was an error in the program source
-    ///
-    /// Option: empty semicolons still count as a statement (so case labels can work)
     pub fn statement(&mut self) -> SyntaxResult<Stmt> {
         let _guard = self.recursion_check();
         // take out 2 guards since this goes through `compound_statement` before calling itself again
@@ -266,7 +262,8 @@ impl<I: Lexer> Parser<I> {
         })
     }
 
-    /// expr_opt: expr ';' | ';'
+    /// `expr_opt: expr ';' | ';'`
+    ///
     /// <http://www.quut.com/c/ANSI-C-grammar-y.html#expression_statement>
     ///
     /// `token` is the delimiter that ends the expression;
@@ -281,9 +278,11 @@ impl<I: Lexer> Parser<I> {
         }
     }
 
+    /// ```yacc
     /// for_statement:
     ///     FOR '(' expr_opt ';' expr_opt ';' expr_opt ') statement
-    ///   | FOR '(' declaration expr_opt ';' expr_opt ') statement
+    ///   | FOR '(' declaration expr_opt ';' expr_opt ') statement;
+    /// ```
     /// <http://www.quut.com/c/ANSI-C-grammar-y.html#iteration_statement>
     fn for_statement(&mut self) -> StmtResult {
         let start = self.expect(Token::Keyword(Keyword::For))?;
@@ -332,7 +331,8 @@ impl<I: Lexer> Parser<I> {
             location: start.location,
         })
     }
-    /// goto_statement: GOTO identifier ';'
+    /// `goto_statement: GOTO identifier ';'`
+    ///
     /// <http://www.quut.com/c/ANSI-C-grammar-y.html#jump_statement>
     fn goto_statement(&mut self) -> StmtResult {
         let start = self.expect(Token::Keyword(Keyword::Goto)).unwrap();

--- a/src/parse/stmt.rs
+++ b/src/parse/stmt.rs
@@ -246,6 +246,7 @@ impl<I: Lexer> Parser<I> {
         })
     }
     /// do_while_statement: DO statement WHILE '(' expr ')' ';'
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#iteration_statement>
     fn do_while_statement(&mut self) -> StmtResult {
         let start = self
             .expect(Token::Keyword(Keyword::Do))
@@ -266,6 +267,7 @@ impl<I: Lexer> Parser<I> {
     }
 
     /// expr_opt: expr ';' | ';'
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#expression_statement>
     ///
     /// `token` is the delimiter that ends the expression;
     /// `token` is usually `;` but sometimes `)` (in `for` loops)
@@ -282,6 +284,7 @@ impl<I: Lexer> Parser<I> {
     /// for_statement:
     ///     FOR '(' expr_opt ';' expr_opt ';' expr_opt ') statement
     ///   | FOR '(' declaration expr_opt ';' expr_opt ') statement
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#iteration_statement>
     fn for_statement(&mut self) -> StmtResult {
         let start = self.expect(Token::Keyword(Keyword::For))?;
         let paren = self.expect(Token::LeftParen)?;
@@ -330,6 +333,7 @@ impl<I: Lexer> Parser<I> {
         })
     }
     /// goto_statement: GOTO identifier ';'
+    /// <http://www.quut.com/c/ANSI-C-grammar-y.html#jump_statement>
     fn goto_statement(&mut self) -> StmtResult {
         let start = self.expect(Token::Keyword(Keyword::Goto)).unwrap();
         let id = self.expect_id()?;

--- a/src/parse/stmt.rs
+++ b/src/parse/stmt.rs
@@ -52,6 +52,7 @@ impl<I: Lexer> Parser<I> {
             Ok(declaration) => Ok(Stmt::new(StmtType::Decl(declaration), decl.location)),
         }
     }
+    /// ```yacc
     /// statement
     /// : labeled_statement
     /// | compound_statement
@@ -61,12 +62,15 @@ impl<I: Lexer> Parser<I> {
     /// | jump_statement
     /// ;
     ///
-    /// labeled_statement:
-    ///     identifier ':' statement
-    ///   | CASE constant_expr ':' statement
-    ///   | DEFAULT ':' statement
+    /// labeled_statement
+    /// : identifier ':' statement
+    /// | CASE constant_expr ':' statement
+    /// | DEFAULT ':' statement
+    /// ;
+    /// ```
     ///
     /// Result: whether there was an error in the program source
+    ///
     /// Option: empty semicolons still count as a statement (so case labels can work)
     pub fn statement(&mut self) -> SyntaxResult<Stmt> {
         let _guard = self.recursion_check();


### PR DESCRIPTION
Private comments using /* */ style comments are ignored because they are not intended for the html docs.