### PR TITLE
Make the top-level API much easier to use

### DIFF
--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -427,9 +427,7 @@ pub(crate) mod test {
     }
     /// Create a new preprocessor with `s` as the input, but without a trailing newline
     pub(crate) fn cpp_no_newline(s: &str) -> PreProcessor {
-        let mut files: Files = Default::default();
-        let id = files.add("<test suite>", String::new().into());
-        PreProcessorBuilder::new(s, id, Box::leak(Box::new(files))).build()
+        PreProcessorBuilder::new(s).build()
     }
 
     #[test]

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -1,13 +1,13 @@
 mod utils;
 
-use rcc::{Opt, JIT};
+use rcc::{Opt, Program, JIT};
 
 #[test]
 fn jit_readme() -> Result<(), Box<dyn std::error::Error>> {
     let _ = env_logger::try_init();
     let path = "tests/runner-tests/readme.c";
     let readme = std::fs::read_to_string(path)?;
-    let (jit, _warnings) = JIT::from_string(readme, Opt::default());
+    let Program { result: jit, .. } = JIT::from_string(readme, Opt::default());
     let code = unsafe { jit?.run_main() };
     assert_eq!(code, Some(6));
     Ok(())

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -41,17 +41,17 @@ pub fn compile_and_run(program: &str, path: PathBuf, args: &[&str]) -> Result<Ou
     run(&output, args).map_err(Error::IO)
 }
 
-pub fn compile(program: &str, path: PathBuf, no_link: bool) -> Result<tempfile::TempPath, Error> {
-    let opts = Default::default();
-    let mut files = rcc::Files::default();
-    let source = rcc::Source {
-        code: String::from(program).into(),
-        path,
+pub fn compile(
+    program: &str,
+    filename: PathBuf,
+    no_link: bool,
+) -> Result<tempfile::TempPath, Error> {
+    let opts = rcc::Opt {
+        filename,
+        ..Default::default()
     };
-    let id = files.add("<test-suite>", source);
     let module = rcc::initialize_aot_module(program.to_owned());
-    let (result, _warnings) = rcc::compile(module, program, opts, id, &mut files);
-    let module = result?.finish();
+    let module = rcc::compile(module, program, opts).result?.finish();
     let output = tempfile::NamedTempFile::new()
         .expect("cannot create tempfile")
         .into_temp_path();


### PR DESCRIPTION
- Return `Files` instead of requiring it to be provided
- Use `Program` struct instead of an tuple and type alias
- Allow `filename` to be passed so that local includes work properly
     - This also moves `filename` from `BinOpt` to `Opt`