### PR TITLE
Close #421

### DIFF
--- a/src/analyze/init.rs
+++ b/src/analyze/init.rs
@@ -15,7 +15,7 @@ impl<T: Lexer> Analyzer<T> {
         // initializer_list
         let mut expr = match init {
             Aggregate(list) => return self.check_aggregate_overflow(list, ctype, location),
-            Scalar(expr) => self.parse_expr(*expr),
+            Scalar(expr) => self.expr(*expr),
         };
         // The only time (that I know of) that an expression will initialize a non-scalar
         // is for character literals.
@@ -110,7 +110,7 @@ impl<T: Lexer> Analyzer<T> {
                     } else {
                         let expr = match list.next() {
                             Some(Scalar(expr)) => self
-                                .parse_expr(*expr)
+                                .expr(*expr)
                                 .rval()
                                 .implicit_cast(&inner, &mut self.error_handler),
                             _ => unreachable!(),

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -594,7 +594,7 @@ impl<I: Lexer> Analyzer<I> {
             };
             // struct s { int i: 5 };
             if let Some(bitfield) = bitfield {
-                let bit_size = match Self::const_uint(self.parse_expr(bitfield)) {
+                let bit_size = match Self::const_uint(self.expr(bitfield)) {
                     Ok(e) => e,
                     Err(err) => {
                         self.error_handler.push_back(err);
@@ -701,7 +701,7 @@ impl<I: Lexer> Analyzer<I> {
         for (name, maybe_value) in ast_members {
             // enum E { A = 5 };
             if let Some(value) = maybe_value {
-                discriminant = Self::const_sint(self.parse_expr(value)).unwrap_or_else(|err| {
+                discriminant = Self::const_sint(self.expr(value)).unwrap_or_else(|err| {
                     self.error_handler.push_back(err);
                     std::i64::MIN
                 });
@@ -850,7 +850,7 @@ impl<I: Lexer> Analyzer<I> {
             Array { of, size } => {
                 // int a[5]
                 let size = if let Some(expr) = size {
-                    let size = Self::const_uint(self.parse_expr(*expr)).unwrap_or_else(|err| {
+                    let size = Self::const_uint(self.expr(*expr)).unwrap_or_else(|err| {
                         self.error_handler.push_back(err);
                         1
                     });
@@ -1380,7 +1380,7 @@ pub(crate) mod test {
     }
 
     pub(crate) fn analyze_expr(s: &str) -> CompileResult<Expr> {
-        analyze(s, Parser::expr, Analyzer::parse_expr)
+        analyze(s, Parser::expr, Analyzer::expr)
     }
 
     pub(crate) fn assert_decl_display(left: &str, right: &str) {

--- a/src/analyze/stmt.rs
+++ b/src/analyze/stmt.rs
@@ -73,9 +73,8 @@ impl<T: Lexer> FunctionAnalyzer<'_, T> {
                 // Or encode that in the type somehow?
                 self.enter_scope();
                 let initializer = self.parse_stmt(*initializer);
-                let condition = condition.map(|e| {
-                    Box::new(self.expr(*e).truthy(&mut self.analyzer.error_handler))
-                });
+                let condition = condition
+                    .map(|e| Box::new(self.expr(*e).truthy(&mut self.analyzer.error_handler)));
                 let post_loop = post_loop.map(|e| Box::new(self.expr(*e)));
                 let body = self.parse_stmt(*body);
                 self.leave_scope(stmt.location);

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -940,7 +940,7 @@ impl<'a> PreProcessor<'a> {
         // TODO: catch expressions that aren't allowed
         // (see https://github.com/jyn514/rcc/issues/5#issuecomment-575339427)
         // TODO: can semantic errors happen here? should we check?
-        Ok(Analyzer::new(parser, false).parse_expr(expr))
+        Ok(Analyzer::new(parser, false).expr(expr))
     }
     /// We saw an `#if`, `#ifdef`, or `#ifndef` token at the start of the line
     /// and want to either take the branch or ignore the tokens within the directive.


### PR DESCRIPTION
`find src/ -name "*.rs" | xargs sed -i '' 's/parse_expr/expr/'`

Also renames
* [FunctionAnalyzer::parse_expr](https://github.com/jyn514/rcc/blob/master/src/analyze/stmt.rs#L7)
* [parse_expr_with_scope](https://github.com/jyn514/rcc/blob/master/src/analyze/expr.rs#L1347)