### PR TITLE
Separate Analyzer and PureAnalyzer

### DIFF
--- a/src/analyze/expr.rs
+++ b/src/analyze/expr.rs
@@ -1,10 +1,9 @@
-use super::Analyzer;
+use super::PureAnalyzer;
 use crate::arch;
 use crate::data::{hir::*, lex::ComparisonToken, *};
 use crate::intern::InternedStr;
-use crate::parse::Lexer;
 
-impl<T: Lexer> Analyzer<T> {
+impl PureAnalyzer {
     pub fn expr(&mut self, expr: ast::Expr) -> Expr {
         use ast::ExprType::*;
 
@@ -1331,7 +1330,7 @@ mod test {
     use crate::analyze::test::analyze;
     use crate::analyze::*;
     pub(crate) fn expr(input: &str) -> CompileResult<Expr> {
-        analyze(input, Parser::expr, Analyzer::expr)
+        analyze(input, Parser::expr, PureAnalyzer::expr)
     }
     fn get_location(r: &CompileResult<Expr>) -> Location {
         match r {

--- a/src/analyze/init.rs
+++ b/src/analyze/init.rs
@@ -1,10 +1,9 @@
 //! 6.7.9 Initialization
 
-use super::Analyzer;
+use super::PureAnalyzer;
 use crate::data::{ast, error::SemanticError, hir::*, types, Location, Type};
-use crate::parse::Lexer;
 
-impl<T: Lexer> Analyzer<T> {
+impl PureAnalyzer {
     pub(super) fn parse_initializer(
         &mut self,
         init: ast::Initializer,

--- a/src/analyze/stmt.rs
+++ b/src/analyze/stmt.rs
@@ -1,8 +1,7 @@
 use super::FunctionAnalyzer;
 use crate::data::{ast, error::SemanticError, hir::*, lex::Locatable, Location};
-use crate::parse::Lexer;
 
-impl<T: Lexer> FunctionAnalyzer<'_, T> {
+impl FunctionAnalyzer<'_> {
     #[inline(always)]
     fn expr(&mut self, expr: ast::Expr) -> Expr {
         self.analyzer.expr(expr)

--- a/src/data/hir.rs
+++ b/src/data/hir.rs
@@ -528,8 +528,8 @@ impl Eq for Symbol {}
 
 #[cfg(test)]
 mod tests {
-    use crate::analyze::test::analyze;
-    use crate::{Analyzer, Locatable, Parser};
+    use crate::analyze::{test::analyze, PureAnalyzer};
+    use crate::{Locatable, Parser};
 
     #[test]
     fn type_display() {
@@ -545,7 +545,7 @@ mod tests {
         for ty in types.iter() {
             let printed_type_name =
                 analyze(*ty, Parser::type_name, |a, Locatable { data, location }| {
-                    Analyzer::parse_typename_test(a, data, location)
+                    PureAnalyzer::parse_typename_test(a, data, location)
                 })
                 .unwrap()
                 .to_string();

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -940,13 +940,13 @@ impl<'a> PreProcessor<'a> {
         // TODO: remove(0) is bad and I should feel bad
         // TODO: this only returns the first error because anything else requires a refactor
         let first = cpp_tokens.remove(0)?;
-        use crate::{analyze::Analyzer, Parser};
+        use crate::{analyze::PureAnalyzer, Parser};
         let mut parser = Parser::new(first, cpp_tokens.into_iter(), false);
         let expr = parser.expr()?;
         // TODO: catch expressions that aren't allowed
         // (see https://github.com/jyn514/rcc/issues/5#issuecomment-575339427)
         // TODO: can semantic errors happen here? should we check?
-        Ok(Analyzer::new(parser, false).expr(expr))
+        Ok(PureAnalyzer::new().expr(expr))
     }
     /// We saw an `#if`, `#ifdef`, or `#ifndef` token at the start of the line
     /// and want to either take the branch or ignore the tokens within the directive.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ pub fn check_semantics(buf: &str, opt: Opt) -> Program<Vec<Locatable<hir::Declar
         }
     }
 
-    let mut warnings = parser.warnings();
+    let mut warnings = parser.inner.warnings();
     warnings.extend(cpp.warnings());
     if hir.is_empty() && errs.is_empty() {
         errs.push_back(cpp.eof().error(SemanticError::EmptyProgram));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ impl<T, E> Program<T, E> {
     }
 }
 
-pub use analyze::Analyzer;
+pub use analyze::{Analyzer, PureAnalyzer};
 pub use data::*;
 // https://github.com/rust-lang/rust/issues/64762
 #[allow(unreachable_pub)]


### PR DESCRIPTION
This allows analyzing expressions/statements/declarations without having
a full parser set up. Useful for crates using rcc as a library.

r? @pythondude325  - do you think the names of the structs look reasonable? I just came up with them off the top of my head.