### PR TITLE
Switch the string interner to lasso

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "^1.0.10"
 target-lexicon = "0.10"
 tempfile = { version = "3", optional = true }
 pico-args = { version = "0.3", optional = true }
-string-interner = { version = "0.7", default-features = false }
+lasso = "0.2"
 codespan = "0.9"
 color-backtrace = { version = "0.4", default-features = false, optional = true }
 counter = "0.4"

--- a/src/intern.rs
+++ b/src/intern.rs
@@ -1,14 +1,14 @@
 use std::fmt;
 use std::sync::RwLock;
 
+use lasso::{Rodeo, Spur};
 use lazy_static::lazy_static;
-use string_interner::{StringInterner, Sym};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct InternedStr(pub Sym);
+pub struct InternedStr(pub Spur);
 
 lazy_static! {
-    pub static ref STRINGS: RwLock<StringInterner<Sym>> = RwLock::new(StringInterner::default());
+    pub static ref STRINGS: RwLock<Rodeo<Spur>> = RwLock::new(Rodeo::default());
     static ref EMPTY_STRING: InternedStr = InternedStr::get_or_intern("");
 }
 
@@ -19,8 +19,7 @@ macro_rules! get_str {
         $crate::intern::STRINGS
             .read()
             .expect("failed to lock String cache for reading")
-            .resolve(tmp)
-            .expect("tried to get value of non-interned string")
+            .resolve(&tmp)
     }};
 }
 


### PR DESCRIPTION
[`lasso`](https://github.com/Kixiron/lasso) is ~50% faster than `string-interner` and does not have the UB and Miri errors that `string-interner` currently does