### PR TITLE
Separate macro replacement from macro parsing

### DIFF
--- a/src/intern.rs
+++ b/src/intern.rs
@@ -4,8 +4,14 @@ use std::sync::RwLock;
 use lasso::{Rodeo, Spur};
 use lazy_static::lazy_static;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct InternedStr(pub Spur);
+
+impl fmt::Debug for InternedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
 
 lazy_static! {
     pub static ref STRINGS: RwLock<Rodeo<Spur>> = RwLock::new(Rodeo::default());

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -40,11 +40,6 @@ use crate::data::*;
 use crate::get_str;
 use crate::Files;
 
-enum PendingToken {
-    Replaced(Token),
-    NeedsReplacement(Token),
-}
-
 /// An easier interface for constructing a preprocessor.
 ///
 /// Here is the example for `PreProcessor::new()` using the builder:
@@ -147,6 +142,11 @@ pub struct PreProcessor<'a> {
     replacer: MacroReplacer<FileProcessor>,
 }
 
+enum PendingToken {
+    Replaced(Token),
+    NeedsReplacement(Token),
+}
+
 impl From<Token> for CppToken {
     fn from(t: Token) -> CppToken {
         CppToken::Token(t)
@@ -231,7 +231,6 @@ impl Iterator for PreProcessor<'_> {
             } else if let Some(token) = self.pending.pop_front() {
                 self.handle_token(token.data, token.location)
             } else {
-                //self.replacer.finished_replacement();
                 // This function does not perform macro replacement,
                 // so if it returns None we got to EOF.
                 match self.next_cpp_token()? {

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -667,16 +667,7 @@ impl<'a> PreProcessor<'a> {
 
         let mut lex_tokens = self.tokens_until_newline().into_iter();
         let mut cpp_tokens = Vec::with_capacity(lex_tokens.len());
-        //assert!(self.replacer.pending.is_empty());
-        /*
-        let mut lex_tokens = lex_tokens
-            .into_iter()
-            .map(|res| res.map(|t| replacer.replace(t.data, t.location)))
-            .flatten()
-            .flatten();
-            */
-        //.collect::<Vec<_>>()
-        //.into_iter();
+
         while let Some(token) = lex_tokens.next() {
             let token = match token {
                 // #if defined(a)
@@ -692,17 +683,6 @@ impl<'a> PreProcessor<'a> {
                     };
                     Ok(location.with(Token::Literal(literal)))
                 }
-                /*
-                // #if a
-                Ok(Locatable {
-                    data: Token::Id(_),
-                    location,
-                }) => {
-                    let token = Token::Literal(Literal::Int(0));
-                    Ok(Locatable::new(token, location))
-                }
-                */
-                // #if 1
                 _ => token,
             };
             cpp_tokens.push(token);
@@ -1073,11 +1053,6 @@ impl<'a> PreProcessor<'a> {
             code: Rc::clone(&src),
         };
         self.replacer.inner.add_file(filename, source);
-        /*
-        let id = self.files.add(filename, source);
-        self.includes
-            .push(Lexer::new(id, src, self.first_lexer.debug));
-            */
         Ok(())
     }
     // Returns every byte between the current position and the next `byte`.

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -106,20 +106,6 @@ impl<'a> PreProcessorBuilder<'a> {
     }
 }
 
-enum Unimplemented {}
-impl Iterator for Unimplemented {
-    type Item = CppResult<Token>;
-    fn next(&mut self) -> Option<Self::Item> {
-        None
-    }
-}
-
-impl Default for Unimplemented {
-    fn default() -> Self {
-        unimplemented!()
-    }
-}
-
 /// A preprocessor does textual substitution and deletion on a C source file.
 ///
 /// The C preprocessor, or `cpp`, is tightly tied to C tokenization.

--- a/src/lex/files.rs
+++ b/src/lex/files.rs
@@ -1,0 +1,162 @@
+use super::Lexer;
+use crate::{
+    data::{CompileResult, Locatable, Token},
+    ErrorHandler, Location,
+};
+use crate::{Files, Source};
+use std::path::Path;
+use std::rc::Rc;
+
+// TODO: this API is absolutely terrible, there's _no_ encapsulation
+pub(super) struct FileProcessor {
+    /// The preprocessor collaborates extremely closely with the lexer,
+    /// since it sometimes needs to know if a token is followed by whitespace.
+    first_lexer: Lexer,
+    /// Each lexer represents a separate source file that is currently being processed.
+    includes: Vec<Lexer>,
+    /// All known files, including files which have already been read.
+    files: Files,
+    pub(super) error_handler: ErrorHandler,
+    current: Option<CompileResult<Locatable<Token>>>,
+}
+
+impl Iterator for FileProcessor {
+    type Item = CompileResult<Locatable<Token>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // we have to duplicate a bit of code here to avoid borrow errors
+            let lexer = self.includes.last_mut().unwrap_or(&mut self.first_lexer);
+            match self
+                .current
+                .take()
+                .or_else(|| lexer.next().map(|r| r.map_err(Into::into)))
+            {
+                Some(token) => return Some(token),
+                // finished this file, go on to the next one
+                None => {
+                    self.error_handler.append(&mut lexer.error_handler);
+                    // this is the original source file
+                    if self.includes.is_empty() {
+                        return None;
+                    } else {
+                        self.includes.pop();
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl FileProcessor {
+    pub(super) fn new(
+        chars: impl Into<Rc<str>>,
+        filename: impl Into<std::ffi::OsString>,
+        debug: bool,
+    ) -> Self {
+        let mut files = Files::new();
+        let chars = chars.into();
+        let filename = filename.into();
+        let source = crate::Source {
+            code: Rc::clone(&chars),
+            path: filename.clone().into(),
+        };
+        let file = files.add(filename, source);
+        Self {
+            error_handler: ErrorHandler::default(),
+            first_lexer: Lexer::new(file, chars, debug),
+            files,
+            includes: Default::default(),
+            current: None,
+        }
+    }
+
+    pub(super) fn peek(&mut self) -> Option<&CompileResult<Locatable<Token>>> {
+        if self.current.is_none() {
+            self.current = self.next();
+        }
+        self.current.as_ref()
+    }
+
+    /// Since there could potentially be multiple lexers (for multiple files),
+    /// this is a convenience function that returns the lexer for the current file.
+    pub(super) fn lexer(&self) -> &Lexer {
+        self.includes.last().unwrap_or(&self.first_lexer)
+    }
+    /// Same as `lexer()` but `&mut self -> &mut Lexer`.
+    pub(super) fn lexer_mut(&mut self) -> &mut Lexer {
+        self.includes.last_mut().unwrap_or(&mut self.first_lexer)
+    }
+    pub(super) fn add_file(&mut self, filename: String, source: Source) {
+        let code = Rc::clone(&source.code);
+        let id = self.files.add(filename, source);
+        self.includes
+            .push(Lexer::new(id, code, self.first_lexer.debug));
+    }
+
+    /// Return a `Location` representing the end of the first file.
+    pub(super) fn eof(&self) -> Location {
+        let lex = &self.first_lexer;
+        Location {
+            span: (lex.chars.len() as u32..lex.chars.len() as u32).into(),
+            file: lex.location.file,
+        }
+    }
+
+    /// Return all files loaded by the preprocessor, consuming it in the process.
+    ///
+    /// Files can be loaded by C source using `#include` directives.
+    pub(super) fn into_files(self) -> Files {
+        self.files
+    }
+
+    /* Convenience functions */
+    #[inline]
+    pub(super) fn line(&self) -> usize {
+        self.lexer().line
+    }
+    #[inline]
+    pub(super) fn span(&self, start: u32) -> Location {
+        self.lexer().span(start)
+    }
+    #[inline]
+    pub(super) fn consume_whitespace(&mut self) {
+        self.lexer_mut().consume_whitespace()
+    }
+    #[inline]
+    pub(super) fn seen_line_token(&self) -> bool {
+        self.lexer().seen_line_token
+    }
+    #[inline]
+    pub(super) fn offset(&self) -> u32 {
+        self.lexer().location.offset
+    }
+
+    /* These functions are really for the benefit of `PreProcessor`, not anyone else. */
+    pub(super) fn path(&self) -> &Path {
+        &self.files.source(self.lexer().location.file).path
+    }
+
+    /// Return all tokens from the current position until the end of the current line.
+    ///
+    /// Note that these are _tokens_ and not bytes, so if there are invalid tokens
+    /// on the current line, this will return a lex error.
+    pub(super) fn tokens_until_newline(&mut self) -> Vec<CompileResult<Locatable<Token>>> {
+        let mut tokens = Vec::new();
+        let line = self.line();
+        loop {
+            self.consume_whitespace();
+            if self.line() != line {
+                // lines should end with a newline, but in case they don't, don't crash
+                assert!(!self.lexer().seen_line_token || self.lexer_mut().peek().is_none(),
+                    "expected `tokens_until_newline()` to reset `seen_line_token`, but `lexer.peek()` is {:?}",
+                    self.lexer_mut().peek());
+                break;
+            }
+            match self.next() {
+                Some(token) => tokens.push(token),
+                None => break,
+            }
+        }
+        tokens
+    }
+}

--- a/src/lex/mod.rs
+++ b/src/lex/mod.rs
@@ -7,11 +7,15 @@ use super::data::{error::LexError, lex::*, *};
 use super::intern::InternedStr;
 
 mod cpp;
+mod files;
+pub mod replace;
 #[cfg(test)]
 mod tests;
 // https://github.com/rust-lang/rust/issues/64762
 #[allow(unreachable_pub)]
-pub use cpp::{Definition, PreProcessor, PreProcessorBuilder};
+pub use cpp::{PreProcessor, PreProcessorBuilder};
+#[allow(unreachable_pub)]
+pub use replace::Definition;
 
 type LexResult<T = Token> = Result<T, Locatable<LexError>>;
 

--- a/src/lex/replace.rs
+++ b/src/lex/replace.rs
@@ -1,0 +1,293 @@
+//! Macro replacement
+//!
+//! This module does no parsing and accepts only tokens.
+
+use super::{cpp::CppResult, files::FileProcessor};
+use crate::{
+    error::CppError, CompileError, CompileResult, InternedStr, Locatable, Location, Token,
+};
+use std::collections::{HashMap, HashSet, VecDeque};
+
+pub trait Peekable: Iterator {
+    fn peek(&mut self) -> Option<&Self::Item>;
+}
+
+impl Peekable for FileProcessor {
+    fn peek(&mut self) -> Option<&Self::Item> {
+        self.peek()
+    }
+}
+
+impl<T: Iterator> Peekable for std::iter::Peekable<T> {
+    fn peek(&mut self) -> Option<&Self::Item> {
+        self.peek()
+    }
+}
+
+pub struct MacroReplacer<I: Iterator<Item = CppResult<Token>>> {
+    /// The ids seen while replacing the current token.
+    ///
+    /// This allows cycle detection. It should be reset after every replacement list
+    /// - _not_ after every token, since otherwise that won't catch some mutual recursion
+    /// See https://github.com/jyn514/rcc/issues/427 for examples.
+    ids_seen: HashSet<InternedStr>,
+    /// Note that this is a simple HashMap and not a Scope, because
+    /// the preprocessor has no concept of scope other than `undef`
+    pub definitions: HashMap<InternedStr, Definition>,
+    /// The token stream to read from
+    pub(crate) inner: I,
+}
+
+#[derive(Debug)]
+pub enum Definition {
+    Object(Vec<Token>),
+    Function {
+        params: Vec<InternedStr>,
+        body: Vec<Token>,
+    },
+}
+
+impl<I: Peekable<Item = CppResult<Token>>> MacroReplacer<I> {
+    pub(super) fn new(tokens: I) -> Self {
+        Self {
+            inner: tokens,
+            definitions: Default::default(),
+            ids_seen: Default::default(),
+        }
+    }
+
+    pub(super) fn with_definitions(
+        tokens: I,
+        definitions: HashMap<InternedStr, Definition>,
+    ) -> Self {
+        Self {
+            definitions,
+            ..Self::new(tokens)
+        }
+    }
+
+    /// Possibly recursively replace tokens.
+    ///
+    /// This first performs object-macro replacement, then function-macro replacement.
+    /// For example, consider this C program:
+    /// ```c
+    /// #define f(a, b) a + b
+    /// #define g f
+    /// #define c d
+    /// g(c, 1)
+    /// ```
+    /// First, the name of the function will be replaced: `f(c, 1)`.
+    /// Next, all arguments are replaced: `f(d, 1)`.
+    /// Finally, function-macros are replaced: `d + 1`.
+    ///
+    /// If at any point there is a cyclic replacement, no error is generated.
+    /// Instead, replacement immediately stops for the current token.
+    /// However, future tokens may still be replaced. For example, take
+    /// ```c
+    /// #define b c
+    /// #define f(a) g(a + 1)
+    /// #define g(a) f(a)
+    /// f(b)
+    /// ```
+    /// The cycle f -> g will be detected after the first time through: `f(b)` -> `g(b + 1)` -> `f(b + 1)`.
+    /// Then, replacements of later tokens occur: `f(c + 1)`.
+    ///
+    /// Note that known cycles do not persist between calls to `replace`.
+    /// This means that very long cycles will be recalculated on each call.
+    ///
+    /// WARNING: if you call `replace()` the wrong way, you can cause an infinite loop.
+    /// Take for example this code (from [#298](https://github.com/jyn514/rcc/issues/298)):
+    /// ```c
+    /// #define sa_handler   __sa_handler.sa_handler
+    /// sa_handler
+    /// ```
+    /// If you implement a naive iterator on top of `MacroReplacer`,
+    /// you'll have a list of pending tokens (since a single underlying token can expand to many tokens).
+    /// If you then feed those tokens back to `replace` in a loop, they will generate infinitely many tokens:
+    /// `replace(sa_handler) -> yield __sa_handler; yield .; replace(sa_handler) -> ...`
+    /// The solution is to keep track of which tokens have already been replaced and not replace them a second time.
+    ///
+    /// In most cases the above will not be relevant since you will only call `replace()` once,
+    /// or only call it on tokens which have not yet been replaced.
+    #[must_use = "does not change internal state"]
+    pub fn replace(
+        &mut self,
+        token: Token,
+        location: Location,
+    ) -> Vec<CompileResult<Locatable<Token>>> {
+        let mut replacements = Vec::new();
+        let mut pending = VecDeque::new();
+        pending.push_back(Ok(location.with(token)));
+
+        // outer loop: replace all tokens in the replacement list
+        while let Some(token) = pending.pop_front() {
+            // first step: perform (recursive) substitution on the ID
+            if let Ok(Locatable {
+                data: Token::Id(id),
+                ..
+            }) = token
+            {
+                if !self.ids_seen.contains(&id) {
+                    match self.definitions.get(&id) {
+                        Some(Definition::Object(replacement_list)) => {
+                            self.ids_seen.insert(id);
+                            // prepend the new tokens to the pending tokens
+                            // They need to go before, not after. For instance:
+                            // ```c
+                            // #define a b c d
+                            // #define b 1 + 2
+                            // a
+                            // ```
+                            // should replace to `1 + 2 c d`, not `c d 1 + 2`
+                            let mut new_pending = VecDeque::new();
+                            // we need a `clone()` because `self.definitions` needs to keep its copy of the definition
+                            new_pending.extend(
+                                replacement_list
+                                    .iter()
+                                    .cloned()
+                                    .map(|t| Ok(location.with(t))),
+                            );
+                            new_pending.append(&mut pending);
+                            pending = new_pending;
+                            continue;
+                        }
+                        // TODO: so many allocations :(
+                        Some(Definition::Function { .. }) => {
+                            self.ids_seen.insert(id);
+                            let func_replacements =
+                                self.replace_function(id, location, &mut pending);
+                            let mut func_replacements: VecDeque<_> =
+                                func_replacements.into_iter().collect();
+                            func_replacements.append(&mut pending);
+                            pending = func_replacements;
+                            continue;
+                        }
+                        None => {}
+                    }
+                }
+            }
+            replacements.push(token);
+        }
+
+        // Since there are no tokens in `self.pending`, we have finished replacing this macro.
+        self.ids_seen.clear();
+        replacements
+    }
+
+    // TODO: this should probably return Result<VecDeque, CompileError> instead
+    #[must_use = "does not change internal state"]
+    fn replace_function(
+        &mut self,
+        id: InternedStr,
+        location: Location,
+        incoming: &mut VecDeque<CompileResult<Locatable<Token>>>,
+    ) -> Vec<Result<Locatable<Token>, CompileError>> {
+        use std::mem;
+
+        let mut errors = Vec::new();
+
+        loop {
+            match incoming.front().or_else(|| self.inner.peek()) {
+                // handle `f @ ( 1 )`, with arbitrarly many token errors
+                Some(Err(_)) => {
+                    let next = incoming.pop_front().or_else(|| self.inner.next());
+                    // TODO: need to figure out what should happen if an error token happens during replacement
+                    errors.push(Err(next.unwrap().unwrap_err()));
+                }
+                // f (
+                Some(Ok(Locatable {
+                    data: Token::LeftParen,
+                    ..
+                })) => {
+                    // pop off the `(` so it isn't counted as part of the first argument
+                    if incoming.pop_front().is_none() {
+                        self.inner.next();
+                    }
+                    break;
+                }
+                // `f ;` or `f <EOF>`
+                Some(_) | None => return errors,
+            }
+        }
+
+        // now, expand all arguments
+        let mut args = Vec::new();
+        let mut current_arg = Vec::new();
+        let mut nested_parens = 1;
+
+        loop {
+            let next = match incoming.pop_front().or_else(|| self.inner.next()) {
+                // f ( <EOF>
+                // TODO: this should give an error
+                None => return errors,
+                // f ( @
+                Some(Err(err)) => {
+                    errors.push(Err(err));
+                    continue;
+                }
+                // f ( +
+                Some(Ok(token)) => token,
+            };
+            match next.data {
+                // f ( a,
+                // NOTE: `f(,)` is _legal_ and means to replace f with two arguments, each an empty token lists
+                // on the bright side, we don't have to check if `current_arg` is empty or not
+                Token::Comma if nested_parens == 1 => {
+                    args.push(mem::take(&mut current_arg));
+                    continue;
+                }
+                // f ( (a + 1)
+                Token::RightParen => {
+                    nested_parens -= 1;
+                    // f ( )
+                    if nested_parens == 0 {
+                        args.push(mem::take(&mut current_arg));
+                        break;
+                    }
+                }
+                // f ( (
+                Token::LeftParen => {
+                    nested_parens += 1;
+                }
+                // f( + )
+                _ => {}
+            }
+            // TODO: keep the location
+            current_arg.push(next.data);
+        }
+
+        let (params, body) = match self.definitions.get(&id) {
+            Some(Definition::Function { params, body }) => (params, body),
+            // TODO: it would be nice to pass in `params` and `body` directly, but that runs into borrow errors
+            _ => unreachable!("checked above"),
+        };
+
+        let mut replacements = Vec::new();
+        if args.len() != params.len() {
+            // booo, this is the _only_ error in the whole replacer
+            return vec![Err(
+                location.with(CppError::TooFewArguments(args.len(), params.len()).into())
+            )];
+        }
+
+        for token in body {
+            if let Token::Id(id) = *token {
+                // #define f(a) { a + 1 } \n f(b) => b + 1
+                if let Some(index) = params.iter().position(|&param| param == id) {
+                    let replacement = args[index].clone();
+                    replacements.extend(replacement);
+                } else {
+                    let token = Token::Id(id);
+                    replacements.push(token);
+                }
+            } else {
+                replacements.push(token.clone());
+            }
+        }
+        // TODO: this collect is useless
+        errors
+            .into_iter()
+            .chain(replacements.into_iter().map(|t| Ok(location.with(t))))
+            .collect()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,8 @@ mod ir;
 mod lex;
 mod parse;
 
+pub use lex::replace;
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{}", .0.iter().map(|err| err.data.to_string()).collect::<Vec<_>>().join("\n"))]


### PR DESCRIPTION
This allows you to replace any iterator of `Token` without having to have the original `&str`.

The core idea is to separate the preprocessor into 3 separate, nested iterators:
1. The innermost iterator (`FileProcessor`) deals with multiple files/lexers. If one included file runs out of tokens, it seamlessly goes on to the next one.
2. The middle iterator (`MacroReplacer`) performs macro replacement.
3. The outermost iterator (`PreProcessor`) deals with preprocessing directives. Additionally, because of the weird way I lumped the lexer and preprocessor together, it recognizes keywords and turns `Token::Id` into `Token::Keyword` as necessary.

The `PreProcessor` sometimes does _not_ want to replace its tokens (e.g. for `#if defined(a)`). In this case, it reaches  _through_ the replacer into the `FileProcessor` to drag out those tokens. Because of this, the `MacroReplacer` _cannot_ have any idea of pending tokens, or its `pending` will conflict with the `PreProcessor`'s  `pending`.

I want to support inputs other than `FileProcessor` (this is the whole point of the PR after all), but at the same time I need to be able to peek ahead in the input to see whether a token defined as a function macro is followed by a `(`. To support both these use cases, I add a new trait called `Peekable`; the intent is that users of `rcc` can use arbitrary iterators over `Token` by calling `iter.peekable()`.

I'm not super happy with how tightly coupled the `PreProcessor` is to the `FileProcessor`, but that's a project for another day.

This also implements `Debug` for `InternedStr` to actually be useful, since I was looking at the debug output a lot.

Needed for https://github.com/rust-lang/rust-bindgen/pull/1782. Closes #436.

r? @pythondude325 