### PR TITLE
Give an error if `#if` has trailing tokens in the expression

### DIFF
--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -478,6 +478,10 @@ pub enum CppError {
     /// b) an `#else` has already been seen.
     #[error("{}", if *early { "#elif without #if" } else { "#elif after #else " })]
     UnexpectedElif { early: bool },
+
+    /// After parsing an `#if` expression, there were tokens left over.
+    #[error("trailing tokens in `#if` expression")]
+    TooManyTokens,
 }
 
 /// Lex errors are non-exhaustive and may have new variants added at any time

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -72,6 +72,13 @@ impl<I: Lexer> Parser<I> {
             recursion_guard: Default::default(),
         }
     }
+    /// Return whether this parser has fully finished parsing.
+    ///
+    /// This can be used if, for example, you call `parser.expr()`
+    /// and want to see if there are any left-over tokens.
+    pub fn is_empty(&mut self) -> bool {
+        self.peek_token().is_none()
+    }
 }
 
 impl<I: Lexer> Iterator for Parser<I> {

--- a/tests/runner-tests/cpp/if/trailing.c
+++ b/tests/runner-tests/cpp/if/trailing.c
@@ -1,0 +1,3 @@
+// compile-fail
+#if 1;
+#endif


### PR DESCRIPTION
Found in https://github.com/rust-lang/rust-bindgen/pull/1782