### PR TITLE
Rename rcc to saltwater

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Writing unit tests for codegen is not really possible,
 since we want to see how the program behaves at runtime,
 and running arbitrary C code in-process is a recipe for disaster.
 
-Instead, rcc uses 'Runner tests', which are C files in
+Instead, saltwater uses 'Runner tests', which are C files in
 `tests/runner-tests` that are compiled and run by `tests/runner.rs`.
 You can control the expected output using a comment at the top of the file
 (usually something like `// succeeds` or `code: 1`).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rcc"
+name = "saltwater"
 version = "0.9.0"
 authors = [
   "Joshua Nelson <jyn514@gmail.com>",
@@ -11,13 +11,13 @@ authors = [
 ]
 edition = "2018"
 description = "A C compiler written in Rust, with a focus on good error messages."
-repository = "https://github.com/jyn514/rcc/"
+repository = "https://github.com/jyn514/saltwater/"
 readme = "README.md"
 categories = ["development-tools", "parser-implementations"]
 license = "BSD-3-Clause"
 keywords = ["C", "compiler", "recursive-descent", "cranelift"]
-default-run = "rcc"
-documentation = "https://docs.rs/rcc"
+default-run = "swcc"
+documentation = "https://docs.rs/saltwater"
 
 [dependencies]
 lazy_static = "1"
@@ -48,7 +48,7 @@ proptest-derive = "0.1"
 
 [features]
 default = ["cc", "codegen", "color-backtrace"]
-# The `rcc` binary
+# The `swcc` binary
 cc = ["ansi_term", "git-testament", "tempfile", "pico-args", "codegen", "atty"]
 codegen = ["cranelift", "cranelift-module", "cranelift-object"]
 jit = ["codegen", "cranelift-simplejit"]
@@ -56,7 +56,7 @@ jit = ["codegen", "cranelift-simplejit"]
 _test_headers = []
 
 [[bin]]
-name = "rcc"
+name = "swcc"
 path = "src/main.rs"
 required-features = ["cc"]
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-# rcc
+# Saltwater
 
 [![Build Status](https://travis-ci.org/jyn514/rcc.svg?branch=master)](https://travis-ci.org/jyn514/rcc)
 [Join us on Discord](https://discord.gg/BPER7PF)
 
-rcc: a Rust C compiler
+saltwater: the part of the sea causing lots of rust
 
 A C compiler written in Rust, with a focus on good error messages.
-Warning: my first rust project, code quality is pretty low.
 
 ## Running
 
-`rcc` reads from standard in by default, so you can type in code directly.
+`swcc` reads from standard in by default, so you can type in code directly.
 It's not interactive though, you have to hit Ctrl+D to indicate end of file (Ctrl+Z on Windows).
 
-Use `rcc --help` for all options (or see [below](#all-options)).
+Use `swcc --help` for all options (or see [below](#all-options)).
 
 ### Running on Windows
 
@@ -63,7 +62,7 @@ int g(int i) {
   }
   return a[i];
 }
-$ rcc tests/runner-tests/readme.c
+$ swcc tests/runner-tests/readme.c
 $️ ./a.out
 j is 6
 ```
@@ -88,12 +87,12 @@ syntax error
 # if defined b && defined(a)
     int main() { return i; }
 #endif
-$ rcc -E tests/runner-tests/cpp/if/defined.c
+$ swcc -E tests/runner-tests/cpp/if/defined.c
 int i = 2 ; int main ( ) { return i ; }
 ```
 
 ```c
-$ echo 'int i = 1 + 2 ^ 3 % 5 / 2 & 1; int main(){}' | rcc --debug-ast
+$ echo 'int i = 1 + 2 ^ 3 % 5 / 2 & 1; int main(){}' | swcc --debug-ast
 ast: int i = ((1) + (2)) ^ ((((3) % (5)) / (2)) & (1));
 ast: int main(){
 }
@@ -105,7 +104,7 @@ $ cat tests/runner-tests/hello_world.c
 int main() {
     puts("Hello, world!");
 }
-$ rcc --debug-ir tests/runner-tests/hello_world.c
+$ swcc --debug-ir tests/runner-tests/hello_world.c
 function u0:0() -> i32 system_v {
     gv0 = symbol colocated u1:3
     sig0 = (i64) -> i32 system_v
@@ -124,13 +123,13 @@ Hello, world!
 ### All options
 
 ```txt
-$ rcc --help
-rcc 0.9.0
+$ swcc --help
+swcc 0.9.0
 Joshua Nelson <jyn514@gmail.com>
 A C compiler written in Rust, with a focus on good error messages.
 Homepage: https://github.com/jyn514/rcc/
 
-usage: rcc [FLAGS] [OPTIONS] [<file>]
+usage: swcc [FLAGS] [OPTIONS] [<file>]
 
 FLAGS:
         --debug-ast        If set, print the parsed abstract syntax tree (AST) in addition to compiling.
@@ -140,7 +139,7 @@ FLAGS:
         --debug-ir         If set, print the intermediate representation (IR) of the program in addition to compiling.
         --debug-lex        If set, print all tokens found by the lexer in addition to compiling.
         --jit              If set, will use JIT compilation for C code and instantly run compiled code (No files produced).
-                            NOTE: this option only works if rcc was compiled with the `jit` feature.
+                            NOTE: this option only works if swcc was compiled with the `jit` feature.
     -h, --help             Prints help information
     -c, --no-link          If set, compile and assemble but do not link. Object file is machine-dependent.
     -E, --preprocess-only  If set, preprocess only, but do not do anything else.

--- a/src/analyze/expr.rs
+++ b/src/analyze/expr.rs
@@ -972,7 +972,7 @@ impl Type {
     ///
     /// Examples:
     /// ```ignore
-    /// use rcc::data::types::Type::*;
+    /// use saltwater::data::types::Type::*;
     /// assert!(Long(true).rank() > Int(true).rank());
     /// assert!(Int(false).rank() > Short(false).rank());
     /// assert!(Short(true).rank() > Char(true).rank());

--- a/src/analyze/mod.rs
+++ b/src/analyze/mod.rs
@@ -1180,7 +1180,7 @@ impl FunctionAnalyzer<'_> {
         location: Location,
     ) -> (Symbol, Vec<Stmt>) {
         let parsed_func = analyzer.parse_type(func.specifiers, func.declarator.into(), location);
-        // rcc ignores `inline` and `_Noreturn`
+        // saltwater ignores `inline` and `_Noreturn`
         if parsed_func.qualifiers != Qualifiers::default() {
             analyzer.error_handler.warn(
                 Warning::FunctionQualifiersIgnored(parsed_func.qualifiers),

--- a/src/data/error.rs
+++ b/src/data/error.rs
@@ -124,7 +124,7 @@ pub enum SemanticError {
     #[error("'{0}' is not a qualifier and cannot be used for pointers")]
     NotAQualifier(ast::DeclarationSpecifier),
 
-    #[error("'{}' is too long for rcc", vec!["long"; *.0].join(" "))]
+    #[error("'{}' is too long for {}", vec!["long"; *.0].join(" "), env!("CARGO_PKG_NAME"))]
     TooLong(usize),
 
     #[error("conflicting storage classes '{0}' and '{1}'")]
@@ -578,7 +578,7 @@ pub enum Warning {
     #[error("declaration does not declare anything")]
     EmptyDeclaration,
 
-    #[error("rcc does not support #pragma")]
+    #[error("{} does not support #pragma", env!("CARGO_PKG_NAME"))]
     IgnoredPragma,
 
     #[error("variadic macros are not yet supported")]

--- a/src/data/types.rs
+++ b/src/data/types.rs
@@ -57,7 +57,7 @@ mod struct_ref {
         ///
         /// Examples:
         /// ```
-        /// use rcc::data::types::StructRef;
+        /// use saltwater::data::types::StructRef;
         /// let struct_ref = StructRef::new();
         /// let members = struct_ref.get();
         /// for symbol in members.iter() {
@@ -79,7 +79,7 @@ mod struct_ref {
         /// Examples:
         ///
         /// ```compile_fail
-        /// use rcc::data::types::StructRef;
+        /// use saltwater::data::types::StructRef;
         /// let struct_ref = StructRef::new();
         /// struct_ref.update(vec![Symbol::new()]);
         /// ```

--- a/src/lex/cpp.rs
+++ b/src/lex/cpp.rs
@@ -17,7 +17,7 @@
 //! but at the same time the `MacroReplacer` needs to be able to peek ahead in the input
 //! to see whether a token defined as a function macro is followed by a `(`.
 //! To support both these use cases, I create a new trait called `Peekable`;
-//! the intent is that users of rcc can use arbitrary iterators over `Token` by calling `iter.peekable()`.
+//! the intent is that users of saltwater can use arbitrary iterators over `Token` by calling `iter.peekable()`.
 //!
 //! TODO: The `PreProcessor` is very tightly coupled to the `FileProcessor`.
 //!
@@ -45,7 +45,7 @@ use crate::Files;
 ///
 /// Here is the example for `PreProcessor::new()` using the builder:
 /// ```
-/// use rcc::PreProcessorBuilder;
+/// use saltwater::PreProcessorBuilder;
 ///
 /// let cpp = PreProcessorBuilder::new("int main(void) { char *hello = \"hi\"; }\n").filename("example.c").build();
 /// for token in cpp {
@@ -121,7 +121,7 @@ impl<'a> PreProcessorBuilder<'a> {
 /// Examples:
 ///
 /// ```
-/// use rcc::PreProcessor;
+/// use saltwater::PreProcessor;
 ///
 /// let cpp = PreProcessor::new("int main(void) { char *hello = \"hi\"; }\n", "example.c", false, vec![], Default::default());
 /// for token in cpp {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,11 @@ use cranelift_module::{Backend, Module};
 pub use ir::initialize_aot_module;
 
 #[cfg(all(feature = "color-backtrace", not(feature = "cc")))]
-compile_error!("The color-backtrace feature does nothing unless used by the `rcc` binary.");
+compile_error!(concat!(
+    "The color-backtrace feature does nothing unless used by the `",
+    env!("CARGO_PKG_DIR"),
+    "` binary."
+));
 
 /// The `Source` type for `codespan::Files`.
 ///

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use rcc::{Opt, Program, JIT};
+use saltwater::{Opt, Program, JIT};
 
 #[test]
 fn jit_readme() -> Result<(), Box<dyn std::error::Error>> {

--- a/tests/stack-overflow.rs
+++ b/tests/stack-overflow.rs
@@ -35,7 +35,7 @@ fn run_all() -> Result<(), io::Error> {
 fn run_one(path: &path::Path) -> Result<(), io::Error> {
     println!("testing {}", path.display());
     let target = std::env::var("CARGO_TARGET_DIR").unwrap_or("target".into());
-    let status = Command::new(format!("{}/debug/rcc", target))
+    let status = Command::new(format!("{}/debug/swcc", target))
         .arg(path)
         .status()
         .unwrap();

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -5,11 +5,10 @@ use std::process::{Command, Output};
 
 extern crate env_logger;
 extern crate log;
-extern crate rcc;
 extern crate tempfile;
 
 use log::info;
-use rcc::Error;
+use saltwater::Error;
 
 pub fn init() {
     env_logger::builder().is_test(true).init();
@@ -46,12 +45,12 @@ pub fn compile(
     filename: PathBuf,
     no_link: bool,
 ) -> Result<tempfile::TempPath, Error> {
-    let opts = rcc::Opt {
+    let opts = saltwater::Opt {
         filename,
         ..Default::default()
     };
-    let module = rcc::initialize_aot_module(program.to_owned());
-    let module = rcc::compile(module, program, opts).result?.finish();
+    let module = saltwater::initialize_aot_module(program.to_owned());
+    let module = saltwater::compile(module, program, opts).result?.finish();
     let output = tempfile::NamedTempFile::new()
         .expect("cannot create tempfile")
         .into_temp_path();
@@ -61,10 +60,10 @@ pub fn compile(
             .expect("cannot create tempfile")
             .into_temp_path();
         info!("tmp_file is {:?}", tmp_file);
-        rcc::assemble(module, &tmp_file)?;
-        rcc::link(&tmp_file, &output)?;
+        saltwater::assemble(module, &tmp_file)?;
+        saltwater::link(&tmp_file, &output)?;
     } else {
-        rcc::assemble(module, &output)?;
+        saltwater::assemble(module, &output)?;
     };
     Ok(output)
 }


### PR DESCRIPTION
 # Why rename rcc?

rcc is a great name for a Rust C compiler. Unfortunately,
that binary name is already being used by the QT project for their
resource compiler: https://doc.qt.io/qt-5/rcc.html. This causes a lot of
confusion when people run `rcc` with QT installed.

 # Why saltwater?

I didn't want to go with synonyms for 'clang' because this is a separate
project which reuses no code or libraries from LLVM. There is an
informal tradition in Rust for having somewhat clever names, so I chose
'saltwater' since it's part of the sea (C) and is corrosive (causes rust).

 # Saltwater is pretty long to type, is that really the new binary name?

No, the binary name is `swcc` (and eventually `swcpp`).

Comments and suggestions for alternative names are welcome.

cc @Byter09 @pythondude325 @repnop @hdamron17 @xtachyon @Kixiron @memoryruins