### PR TITLE
Escape special characters in display

### DIFF
--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -372,7 +372,7 @@ impl std::fmt::Display for Literal {
             UnsignedInt(u) => write!(f, "{}", u),
             Float(n) => write!(f, "{}", n),
             Str(s) => {
-                let escaped = s
+                let mut escaped = s
                     .into_iter()
                     .flat_map(|c| match c {
                         b'\n' => "\\n".bytes().collect(),
@@ -381,6 +381,11 @@ impl std::fmt::Display for Literal {
                         _ => vec![*c],
                     })
                     .collect::<Vec<_>>();
+
+                // Remove the null byte at the end,
+                // because this will break tests and
+                // it's not needed in debug output.
+                escaped.pop();
 
                 write!(f, "\"{}\"", String::from_utf8_lossy(&escaped))
             }
@@ -456,5 +461,13 @@ pub(crate) mod test {
             let first = lexer.next().unwrap().unwrap().data;
             assert_eq!(&first.to_string(), *token);
         }
+    }
+
+    #[test]
+    fn str_display_escape() {
+        let token = "\"Hello, world\\n\"";
+        let mut lexer = cpp(token);
+        let first = lexer.next().unwrap().unwrap().data;
+        assert_eq!(&first.to_string(), token);
     }
 }

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -465,7 +465,7 @@ pub(crate) mod test {
 
     #[test]
     fn str_display_escape() {
-        let token = "\"Hello, world\\n\"";
+        let token = "\"Hello, world\\n\\r\\t\"";
         let mut lexer = cpp(token);
         let first = lexer.next().unwrap().unwrap().data;
         assert_eq!(&first.to_string(), token);

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -385,7 +385,7 @@ impl std::fmt::Display for Literal {
                 // Remove the null byte at the end,
                 // because this will break tests and
                 // it's not needed in debug output.
-                escaped.pop();
+                assert_eq!(escaped.pop(), Some(b'\0'));
 
                 write!(f, "\"{}\"", String::from_utf8_lossy(&escaped))
             }
@@ -465,7 +465,7 @@ pub(crate) mod test {
 
     #[test]
     fn str_display_escape() {
-        let token = "\"Hello, world\\n\\r\\t\"";
+        let token = r#""Hello, world\\n\\r\\t""#;
         let mut lexer = cpp(token);
         let first = lexer.next().unwrap().unwrap().data;
         assert_eq!(&first.to_string(), token);

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -373,7 +373,7 @@ impl std::fmt::Display for Literal {
             Float(n) => write!(f, "{}", n),
             Str(s) => {
                 let mut escaped = s
-                    .into_iter()
+                    .iter()
                     .flat_map(|c| match c {
                         b'\n' => "\\n".bytes().collect(),
                         b'\r' => "\\r".bytes().collect(),

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -371,7 +371,19 @@ impl std::fmt::Display for Literal {
             Int(i) => write!(f, "{}", i),
             UnsignedInt(u) => write!(f, "{}", u),
             Float(n) => write!(f, "{}", n),
-            Str(s) => write!(f, "\"{}\"", String::from_utf8_lossy(s)),
+            Str(s) => {
+                let escaped = s
+                    .into_iter()
+                    .flat_map(|c| match c {
+                        b'\n' => "\\n".bytes().collect(),
+                        b'\r' => "\\r".bytes().collect(),
+                        b'\t' => "\\t".bytes().collect(),
+                        _ => vec![*c],
+                    })
+                    .collect::<Vec<_>>();
+
+                write!(f, "\"{}\"", String::from_utf8_lossy(&escaped))
+            }
             Char(c) => write!(f, "'{}'", char::from(*c).escape_default()),
         }
     }

--- a/src/data/lex.rs
+++ b/src/data/lex.rs
@@ -465,7 +465,7 @@ pub(crate) mod test {
 
     #[test]
     fn str_display_escape() {
-        let token = r#""Hello, world\\n\\r\\t""#;
+        let token = r#""Hello, world\n\r\t""#;
         let mut lexer = cpp(token);
         let first = lexer.next().unwrap().unwrap().data;
         assert_eq!(&first.to_string(), token);


### PR DESCRIPTION
This PR will escape the special characters `\n`, `\r`, and `\t` in the `Display` implementation for a `Literal` node.

Resolves #451 